### PR TITLE
CI: setup GH action to run tests on push

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,6 +5,7 @@
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
 DATABASE_URL="postgresql://prisma:prisma@localhost:5432/dev"
+DATABASE_STATS_URL="postgresql://prisma:prisma@localhost:5432/stats"
 DATABASE_DEV_PORT=5432
 DATABASE_TESTS_PORT=5433
 OIDC_CLIENT_ID=<TO INSERT> # voir https://partenaires.franceconnect.gouv.fr/fcp/fournisseur-service

--- a/.env.test.sample
+++ b/.env.test.sample
@@ -1,6 +1,6 @@
-DATABASE_URL="postgresql://user@localhost:5432/tests"
-DATABASE_STATS_URL="postgresql://user@localhost:5432/stats"
-INTERNAL_TOKEN_SECRET=XXXXX
+DATABASE_URL="postgresql://prisma:prisma@localhost:5432/tests"
+DATABASE_STATS_URL="postgresql://prisma:prisma@localhost:5432/stats"
+INTERNAL_TOKEN_SECRET=123456789012345678901234567890
 
 ## optionel, pour les test d'API externes
 OPEN_ROUTE_API_KEY=XXX

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,4 @@ updates:
       - dependencies
     allow:
       - dependency-name: '@betagouv/aides-velo'
+      - dependency-name: '@incubateur-ademe/nosgestesclimat'

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -1,0 +1,25 @@
+name: Build and run tests
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm run test

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -52,4 +52,4 @@ jobs:
         env:
           DATABASE_URL: 'postgresql://prisma:prisma@localhost:5432/tests'
           DATABASE_STATS_URL: 'postgresql://prisma:prisma@localhost:5432/stats'
-          INTERNAL_TOKEN_SECRET: ${{ secrets.INTERNAL_TOKEN_SECRET }}
+          INTERNAL_TOKEN_SECRET: '123456789012345678901234567890'

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -21,5 +21,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Test
-        run: npm run test
+      - name: Unit tests
+        run: npm run test:unit
+
+      - name: Integration tests
+        run: npm run db:up && npm run test:int && npm run db:down

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   build:
+    name: Build and run tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -14,6 +15,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+
+      - uses: KengoTODA/actions-setup-docker-compose@v1
+        with:
+          version: '2.14.2' # the full version of `docker-compose` command
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -1,12 +1,32 @@
 name: Build and run tests
 
 on:
+  pull_request:
   push:
+    branches:
+      - main
+      - develop
 
 jobs:
   build:
     name: Build and run tests
     runs-on: ubuntu-latest
+
+    services:
+      db-tests:
+        image: postgres:14
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          POSTGRES_USER: prisma
+          POSTGRES_PASSWORD: prisma
+          POSTGRES_DB: tests
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -15,10 +35,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-
-      - uses: KengoTODA/actions-setup-docker-compose@v1
-        with:
-          version: '2.14.2' # the full version of `docker-compose` command
 
       - name: Install dependencies
         run: npm ci
@@ -30,4 +46,10 @@ jobs:
         run: npm run test:unit
 
       - name: Integration tests
-        run: npm run db:up && npm run test:int && npm run db:down
+        run: |
+          npm run db:update
+          npm run test:int
+        env:
+          DATABASE_URL: 'postgresql://prisma:prisma@localhost:5432/tests'
+          DATABASE_STATS_URL: 'postgresql://prisma:prisma@localhost:5432/stats'
+          INTERNAL_TOKEN_SECRET: ${{ secrets.INTERNAL_TOKEN_SECRET }}

--- a/test/unit/infrastructure/ngc/NGCCalculator.spec.ts
+++ b/test/unit/infrastructure/ngc/NGCCalculator.spec.ts
@@ -1,15 +1,16 @@
 import { NGCCalculator } from '../../../../src/infrastructure/ngc/NGCCalculator';
 
 describe('NGCCalculator', () => {
+  const calculator = new NGCCalculator();
+
   it('constructor : no exception', () => {
     //WHEN
-    let calculator = new NGCCalculator();
     //THEN
     expect(calculator).toBeDefined();
   });
+
   it('computeSingleEntry : compute ok single entry, empty situation', () => {
     //GIVEN
-    let calculator = new NGCCalculator();
     const situation = {};
     const entry = 'transport . voiture . empreinte moyenne';
 
@@ -21,7 +22,6 @@ describe('NGCCalculator', () => {
   });
   it('computeSingleEntry : compute ok single entry, minimal situation', () => {
     //GIVEN
-    let calculator = new NGCCalculator();
     const situation = {
       'transport . voiture . km': { valeur: 11000, unité: 'km/an' },
     };
@@ -35,7 +35,6 @@ describe('NGCCalculator', () => {
   });
   it('computeSingleEntry : compute ok single entry, complexe situation', () => {
     //GIVEN
-    let calculator = new NGCCalculator();
     const situation = {
       'transport . voiture . km': { valeur: 12000, unité: 'km/an' },
       'transport . voiture . gabarit': "'VUL'",
@@ -57,7 +56,6 @@ describe('NGCCalculator', () => {
   });
   it('computeSingleEntry : Cas du photovlotaique', () => {
     //GIVEN
-    let calculator = new NGCCalculator();
     const situation1 = {
       'logement . électricité . photovoltaique . présent': 'non',
     };
@@ -75,7 +73,6 @@ describe('NGCCalculator', () => {
   });
   it('computeEntryList : compute ok multiple entries', () => {
     //GIVEN
-    let calculator = new NGCCalculator();
     const situation = {
       'transport . voiture . km': 12000,
       'transport . voiture . gabarit': "'VUL'",
@@ -110,7 +107,6 @@ describe('NGCCalculator', () => {
 
   it(`est applicable : indique que la question n'est pas applicable`, () => {
     //GIVEN
-    let calculator = new NGCCalculator();
     const situation = { 'transport . voiture . km': 0 };
     const entry = 'transport . voiture . motorisation';
 
@@ -122,18 +118,16 @@ describe('NGCCalculator', () => {
       'transport . voiture . motorisation',
     );
   });
+
   it('listerToutesLesClésDeQuestions : liste toutes les clés', () => {
     //GIVEN
-    let calculator = new NGCCalculator();
-
     //WHEN
     const result = calculator.listerToutesLesClésDeQuestions();
     //THEN
   });
-  it(' listeQuestionsAvecConditionApplicabilité : liste toutes les clés de questions avec conditions', () => {
-    //GIVEN
-    let calculator = new NGCCalculator();
 
+  it('listeQuestionsAvecConditionApplicabilité : liste toutes les clés de questions avec conditions', () => {
+    //GIVEN
     //WHEN
     const result = calculator.listeQuestionsAvecConditionApplicabilité();
 


### PR DESCRIPTION
### CHANGELOG

- Mise en place d'une github action minimale
- Mise à jours de dépendances du dependabot
- Refactoring des tests de `NGCCalculator`
  > Comme un `shallowCopy` est effectué pour chaque méthode de `NGCCalculator`, il ne semble pas nécessaire d'instancier un nouveau `calculator` pour chaque tests. Cela permet de diviser par deux le temps d'exécution de `test/unit/infrastructure/ngc/NGCCalculator.spec.ts`.