### PR TITLE
Feat: Ajoute la nouvelle route `/aides/recupererAidesVeloParCodeCommuneOuEPCI`

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -30,6 +30,9 @@ MINIATURES_URL=http://localhost:3000
 OTP_DEV=XXXX
 USER_CURRENT_VERSION=0
 
+# Increase the API throttle limit for testing
+THROTTLE_LIMIT=10
+
 CMS_URL=XXX
 
 CMS_API_KEY=XXX

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -54,3 +54,4 @@ jobs:
           DATABASE_STATS_URL: 'postgresql://prisma:prisma@localhost:5432/stats'
           INTERNAL_TOKEN_SECRET: '123456789012345678901234567890'
           MINIATURES_URL: 'http://localhost:3000'
+          THROTTLE_LIMIT: 10

--- a/src/domain/aides/aideVelo.ts
+++ b/src/domain/aides/aideVelo.ts
@@ -12,8 +12,10 @@ export type AideVelo = {
   logo?: string;
 };
 
-export type AidesVeloParType = {
-  [category in Questions['vélo . type']]: AideVelo[];
+export type AideVeloNonCalculee = Omit<AideVelo, 'plafond' | 'montant'>;
+
+export type AidesVeloParType<A = AideVelo> = {
+  [category in Questions['vélo . type']]: A[];
 };
 
 export const NB_VELO_TYPES = 8;

--- a/src/domain/app.ts
+++ b/src/domain/app.ts
@@ -126,6 +126,9 @@ export class App {
   public static getLVO_API_URL(): string {
     return process.env.LVO_API_URL || '';
   }
+  public static getThrottleLimit(): number {
+    return parseInt(process.env.THROTTLE_LIMIT) ?? 2;
+  }
 
   public static getBasicLoginPwdBase64(): string {
     const login = this.getBasicLogin();

--- a/src/infrastructure/api/aides.controller.ts
+++ b/src/infrastructure/api/aides.controller.ts
@@ -23,6 +23,9 @@ import { AidesVeloParTypeAPI } from './types/aide/AidesVeloParTypeAPI';
 import { InputAideVeloAPI } from './types/aide/inputAideVeloAPI';
 import { InputAideVeloOpenAPI } from './types/aide/inputAideVeloOpenAPI';
 import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
+import { InputRecupererAideVeloAPI } from './types/aide/InputRecupererAideVeloAPI';
+import { AideVeloNonCalculeeAPI } from './types/aide/AideVeloNonCalculeesAPI';
+import { App } from '../../domain/app';
 
 @Controller()
 @ApiBearerAuth()
@@ -104,7 +107,7 @@ export class AidesController extends GenericControler {
   }
 
   @UseGuards(ThrottlerGuard)
-  @Throttle({ default: { limit: 2, ttl: 1000 } })
+  @Throttle({ default: { limit: App.getThrottleLimit(), ttl: 1000 } })
   @ApiOkResponse({ type: AidesVeloParTypeAPI })
   @Post('aides/simulerAideVelo')
   @ApiBody({
@@ -121,5 +124,29 @@ export class AidesController extends GenericControler {
       body.etat_du_velo,
     );
     return AidesVeloParTypeAPI.mapToAPI(result);
+  }
+
+  // NOTE: this could manage region and departement code as well in the future
+  @UseGuards(ThrottlerGuard)
+  @Throttle({ default: { limit: App.getThrottleLimit(), ttl: 1000 } })
+  @ApiOkResponse({ type: AidesVeloParTypeAPI })
+  @Post('aides/recupererAideVeloParCodeCommuneOuEPCI')
+  @ApiBody({
+    type: InputRecupererAideVeloAPI,
+  })
+  @ApiOperation({
+    summary:
+      "Récupère l'ensemble des aides vélo disponibile pour une commune ou un EPCI",
+    description:
+      "Par disponible, on entend que l'aide est disponible pour la commune ou l'EPCI, mais pas nécessairement proposée par cette dernière. Par exemple, une aide proposée par la région est disponible aux habitant:es d'une commune de la région.",
+  })
+  async recupererAidesVeloParCodeCommuneOuEPCI(
+    @Body() body: InputRecupererAideVeloAPI,
+  ): Promise<AideVeloNonCalculeeAPI[]> {
+    const result =
+      await this.aidesUsecase.recupererToutesLesAidesDisponiblesParCommuneOuEPCI(
+        body.code_insee_ou_siren,
+      );
+    return result.map(AideVeloNonCalculeeAPI.mapToAPI);
   }
 }

--- a/src/infrastructure/api/synthese_v2.controller.ts
+++ b/src/infrastructure/api/synthese_v2.controller.ts
@@ -116,7 +116,7 @@ export class Synthese_v2Controller extends GenericControler {
     const liste_articles = await this.articleRepository.searchArticles({});
 
     const IS_CODE_EPCI =
-      this.communeRepository.isCodeInseeEPCI(code_insee_input);
+      this.communeRepository.isCodeSirenEPCI(code_insee_input);
 
     let code_region_cible;
     let code_departement_cible;
@@ -126,7 +126,7 @@ export class Synthese_v2Controller extends GenericControler {
     let liste_noms_communes_of_input: string[];
 
     if (IS_CODE_EPCI) {
-      const EPCI = this.communeRepository.getEPCIByCode(code_insee_input);
+      const EPCI = this.communeRepository.getEPCIBySIRENCode(code_insee_input);
       liste_noms_communes_of_input = EPCI.membres.map((m) => m.nom);
 
       liste_codes_communes_of_input =

--- a/src/infrastructure/api/types/aide/AideVeloNonCalculeesAPI.ts
+++ b/src/infrastructure/api/types/aide/AideVeloNonCalculeesAPI.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CollectiviteAPI } from './AidesVeloParTypeAPI';
+import { AideVeloNonCalculee } from 'src/domain/aides/aideVelo';
+
+export class AideVeloNonCalculeeAPI {
+  @ApiProperty()
+  libelle: string;
+
+  @ApiProperty()
+  lien: string;
+
+  @ApiProperty({ type: CollectiviteAPI })
+  collectivite: CollectiviteAPI;
+
+  @ApiProperty()
+  description: string;
+
+  @ApiProperty({ nullable: true })
+  logo?: string;
+
+  public static mapToAPI(
+    aideVelo: AideVeloNonCalculee,
+  ): AideVeloNonCalculeeAPI {
+    return {
+      libelle: aideVelo.libelle,
+      lien: aideVelo.lien,
+      collectivite: CollectiviteAPI.mapToAPI(aideVelo.collectivite),
+      description: aideVelo.description,
+      logo: aideVelo.logo,
+    };
+  }
+}

--- a/src/infrastructure/api/types/aide/InputRecupererAideVeloAPI.ts
+++ b/src/infrastructure/api/types/aide/InputRecupererAideVeloAPI.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class InputRecupererAideVeloAPI {
+  @ApiProperty({
+    description: "Code INSEE de la commune ou SIREN de l'EPCI",
+    required: true,
+  })
+  code_insee_ou_siren: string;
+}

--- a/src/infrastructure/repository/aidesVelo.repository.ts
+++ b/src/infrastructure/repository/aidesVelo.repository.ts
@@ -92,7 +92,11 @@ export class AidesVeloRepository {
 
     return this.engine
       .getAllAidesIn()
-      .filter(({ collectivity }) => {
+      .filter(({ id, collectivity }) => {
+        if (AIDES_TO_EXCLUDE.includes(id)) {
+          return false;
+        }
+
         switch (collectivity.kind) {
           case 'pays': {
             return isLocalisationEqual('localisation . pays', collectivity);
@@ -117,7 +121,6 @@ export class AidesVeloRepository {
           }
         }
       })
-      .filter(({ id }) => !AIDES_TO_EXCLUDE.includes(id))
       .map((aide) => ({
         libelle: aide.title,
         lien: aide.url,

--- a/src/infrastructure/repository/aidesVelo.repository.ts
+++ b/src/infrastructure/repository/aidesVelo.repository.ts
@@ -9,7 +9,11 @@ import {
 
 import { App } from '../../../src/domain/app';
 import miniatures from '../../../src/infrastructure/data/miniatures.json';
-import { AideVelo, AidesVeloParType } from '../../domain/aides/aideVelo';
+import {
+  AideVeloNonCalculee,
+  AidesVeloParType,
+  Collectivite,
+} from '../../domain/aides/aideVelo';
 
 /**
  * Aids to exclude from the results.
@@ -44,6 +48,15 @@ export type SummaryVelosParams = Required<
   >
 >;
 
+type Localisation = Pick<
+  Questions,
+  | 'localisation . pays'
+  | 'localisation . département'
+  | 'localisation . région'
+  | 'localisation . epci'
+  | 'localisation . code insee'
+>;
+
 @Injectable()
 export class AidesVeloRepository {
   private engine: AidesVeloEngine;
@@ -52,13 +65,66 @@ export class AidesVeloRepository {
     this.engine = new AidesVeloEngine();
   }
 
-  async getSummaryVelos(params: SummaryVelosParams): Promise<AidesVeloParType> {
+  getSummaryVelos(params: SummaryVelosParams): AidesVeloParType {
     const situationBase: Questions = {
       ...params,
       'localisation . pays': 'France',
     };
 
     return this.getAidesVeloTousTypes(situationBase);
+  }
+
+  /**
+   * Get all the aids available for the given location.
+   *
+   * @param localisation - The location to get the aids for. If a field is omitted, all the aids for this scope will be ignored.
+   * @return The list of all the aids available for the given location. Note that they aren't computed, therefore, there is no `montant` or `plafond` field.
+   *
+   * NOTE: should we add a way to collect the `plafond` field?
+   */
+  getAllAidesIn(localisation: Localisation): AideVeloNonCalculee[] {
+    const isLocalisationEqual = (
+      key: keyof Localisation,
+      collectivity: Collectivite,
+    ): boolean => {
+      return localisation[key] && localisation[key] === collectivity.value;
+    };
+
+    return this.engine
+      .getAllAidesIn()
+      .filter(({ collectivity }) => {
+        switch (collectivity.kind) {
+          case 'pays': {
+            return isLocalisationEqual('localisation . pays', collectivity);
+          }
+          case 'département': {
+            return isLocalisationEqual(
+              'localisation . département',
+              collectivity,
+            );
+          }
+          case 'région': {
+            return isLocalisationEqual('localisation . région', collectivity);
+          }
+          case 'epci': {
+            return isLocalisationEqual('localisation . epci', collectivity);
+          }
+          case 'code insee': {
+            return isLocalisationEqual(
+              'localisation . code insee',
+              collectivity,
+            );
+          }
+        }
+      })
+      .filter(({ id }) => !AIDES_TO_EXCLUDE.includes(id))
+      .map((aide) => ({
+        libelle: aide.title,
+        lien: aide.url,
+        collectivite: aide.collectivity,
+        description: getDescription(aide.description),
+        logo: getLogo(aide.id),
+      }));
   }
 
   private getAidesVeloTousTypes(situationBase: Questions): AidesVeloParType {
@@ -80,27 +146,31 @@ export class AidesVeloRepository {
         .setInputs(situationBase)
         .computeAides()
         .filter(({ id }) => !AIDES_TO_EXCLUDE.includes(id))
-        .map(
-          (aide: Aide) => ({
-            libelle: aide.title,
-            montant: aide.amount,
-            description: aide.description.trim(),
-            lien: aide.url,
-            collectivite: aide.collectivity,
-            logo: `${App.getAideVeloMiniaturesURL()}/${miniatures[aide.id]}`,
-            // NOTE: this is legacy behavior, the plafond is the same as the
-            // amount we should consider removing this field or implementing it
-            // correctly.
-            // NOTE: after checking, it seems that the plafond is only used for
-            // the aides retrofits repository, they shouldn't share the same type
-            // or it should be refactored to have a generic type.
-            plafond: aide.amount,
-          }),
-          // HACK: limits of TS inference, without this, there is no error when
-          // returning an array of `Aide` instead of `AideVelo`.
-        ) as AideVelo[];
+        .map((aide: Aide) => ({
+          libelle: aide.title,
+          montant: aide.amount,
+          description: getDescription(aide.description),
+          lien: aide.url,
+          collectivite: aide.collectivity,
+          logo: getLogo(aide.id),
+          // NOTE: this is legacy behavior, the plafond is the same as the
+          // amount we should consider removing this field or implementing it
+          // correctly.
+          // NOTE: after checking, it seems that the plafond is only used for
+          // the aides retrofits repository, they shouldn't share the same type
+          // or it should be refactored to have a generic type.
+          plafond: aide.amount,
+        }));
     }
 
     return veloTypes;
   }
+}
+
+function getLogo(id: string): string {
+  return `${App.getAideVeloMiniaturesURL()}/${miniatures[id]}`;
+}
+
+function getDescription(description: string): string {
+  return description.trim();
 }

--- a/src/infrastructure/repository/commune/commune.repository.ts
+++ b/src/infrastructure/repository/commune/commune.repository.ts
@@ -101,7 +101,15 @@ export class CommuneRepository {
     }
   }
 
-  public getEPCIByCode(code: string): EPCI {
+  /**
+   * Get the EPCI by its SIREN code.
+   *
+   * @param code The SIREN code of the EPCI (e.g. "200000172").
+   * @returns The EPCI if found, `undefined` otherwise.
+   *
+   * PERF: could we use a more clever data structure to have a O(1) lookup?
+   */
+  public getEPCIBySIRENCode(code: string): EPCI | undefined {
     return epci.find((e) => e.code === code);
   }
 
@@ -215,6 +223,7 @@ export class CommuneRepository {
     return result ? result.nom : 'INCONNU';
   }
 
+  // NOTE: why some methods are public and some are protected?
   public getNomRegionByCode(code: string): string {
     const result = (_regions as Region[]).find((d) => d.code === code);
     return result ? result.nom : 'INCONNU';
@@ -224,8 +233,9 @@ export class CommuneRepository {
     return _codes_postaux[code_postal] !== undefined;
   }
 
-  isCodeInseeEPCI(code_insee: string): boolean {
-    return epci.find((e) => e.code === code_insee) != undefined;
+  // PERF: could we use a more clever data structure to have a O(1) lookup?
+  isCodeSirenEPCI(code_siren: string): boolean {
+    return epci.find((e) => e.code === code_siren) != undefined;
   }
 
   checkOKCodePostalAndCommune(code_postal: string, commune: string): boolean {
@@ -238,6 +248,7 @@ export class CommuneRepository {
     if (liste === undefined) return [];
     return liste.map((a) => a.commune);
   }
+
   getListCodesCommunesParCodePostal(code_postal: string): string[] {
     const liste: CommuneParCodePostal[] = _codes_postaux[code_postal];
     if (liste === undefined) return [];
@@ -274,7 +285,7 @@ export class CommuneRepository {
   }
 
   listeCodesCommunesByEPCICode(code_epci: string): string[] {
-    const the_epci = this.getEPCIByCode(code_epci);
+    const the_epci = this.getEPCIBySIRENCode(code_epci);
     const result = [];
 
     for (const membre of the_epci.membres) {
@@ -297,7 +308,7 @@ export class CommuneRepository {
         continue;
       }
 
-      const epci = this.getEPCI(epciCode);
+      const epci = this.getEPCIBySIRENCode(epciCode);
       if (epci?.type === echelon) {
         result.add(epci.nom);
       }
@@ -373,6 +384,7 @@ export class CommuneRepository {
     const liste: CommuneParCodePostal[] = _codes_postaux[code_postal];
     return liste ? liste : [];
   }
+
   public getCodePostauxFromCodeCommune(code_commune: string) {
     for (const une_commune of communes) {
       if (une_commune.code === code_commune) {
@@ -404,18 +416,6 @@ export class CommuneRepository {
    */
   getEPCIByCommuneCodeINSEE(code_insee: string): EPCI | undefined {
     const epciCode = communesEPCI[code_insee];
-    return this.getEPCI(epciCode);
-  }
-
-  /**
-   * Returns the EPCI identified by its SIREN code.
-   *
-   * @param code The SIREN code of the EPCI (e.g. "200000172").
-   * @returns The EPCI if found, `undefined` otherwise.
-   */
-  private getEPCI(code?: string): EPCI | undefined {
-    if (code) {
-      return epci.find((epci) => epci.code === code);
-    }
+    return this.getEPCIBySIRENCode(epciCode);
   }
 }

--- a/test/integration/api/aide.controller.int-spec.ts
+++ b/test/integration/api/aide.controller.int-spec.ts
@@ -629,7 +629,6 @@ Cependant, une période transitoire permet de pouvoir continuer de bénéficier 
 
     // THEN
     expect(response.status).toBe(201);
-    console.log(response.body);
     expect(response.body['cargo électrique']).toEqual([
       {
         collectivite: {
@@ -659,7 +658,6 @@ Dispositif valable jusqu'au 31 décembre 2024.`,
 
     // THEN
     expect(response.status).toBe(201);
-    console.log(response.body);
     expect(response.body['cargo électrique']).toEqual([
       {
         collectivite: {
@@ -676,5 +674,92 @@ Dispositif valable jusqu'au 31 décembre 2024.`,
         plafond: 250,
       },
     ]);
+  });
+
+  describe('POST /aides/recupererAideVeloParCodeCommuneOuEPCI', () => {
+    test('OK avec un code INSEE (Ville de Merignac)', async () => {
+      // WHEN
+      const response = await TestUtil.POST(
+        '/aides/recupererAideVeloParCodeCommuneOuEPCI',
+      ).send({
+        code_insee_ou_siren: '33281',
+      });
+
+      // EXPECT
+      expect(response.status).toBe(201);
+      expect(response.body).toHaveLength(3);
+      expect(response.body[0].collectivite).toEqual({
+        kind: 'pays',
+        value: 'France',
+      });
+      expect(response.body[1].collectivite).toEqual({
+        kind: 'epci',
+        code: '243300316',
+        value: 'Bordeaux Métropole',
+      });
+      expect(response.body[2].collectivite).toEqual({
+        kind: 'code insee',
+        value: '33281',
+      });
+    });
+
+    test('OK avec un code SIREN (Bordeaux Métropole)', async () => {
+      // WHEN
+      const response = await TestUtil.POST(
+        '/aides/recupererAideVeloParCodeCommuneOuEPCI',
+      ).send({
+        code_insee_ou_siren: '243300316',
+      });
+
+      // EXPECT
+      expect(response.status).toBe(201);
+      expect(response.body).toHaveLength(2);
+      expect(response.body[0].collectivite).toEqual({
+        kind: 'pays',
+        value: 'France',
+      });
+      expect(response.body[1].collectivite).toEqual({
+        kind: 'epci',
+        code: '243300316',
+        value: 'Bordeaux Métropole',
+      });
+    });
+
+    test('OK avec récupération des aides régionales et départementales (Montpellier)', async () => {
+      // WHEN
+      const response = await TestUtil.POST(
+        '/aides/recupererAideVeloParCodeCommuneOuEPCI',
+      ).send({
+        code_insee_ou_siren: '34172',
+      });
+
+      // EXPECT
+      expect(response.status).toBe(201);
+      expect(response.body).toHaveLength(7);
+      expect(response.body[0].libelle).toBe('Bonus vélo');
+      expect(response.body[1].libelle).toContain('Région Occitanie');
+      expect(response.body[1].description).toContain(
+        "Achat d'un vélo à assistance électrique",
+      );
+      expect(response.body[2].libelle).toContain('Région Occitanie');
+      expect(response.body[2].description).toContain('Bonus vélo adapté PMR');
+      expect(response.body[3].libelle).toContain('Département Hérault');
+      expect(response.body[4].libelle).toContain('Département Hérault');
+      expect(response.body[4].description).toContain(
+        'Chèque Hérault Handi-Vélo',
+      );
+      expect(response.body[5].libelle).toContain(
+        'Montpellier Méditerranée Métropole',
+      );
+      expect(response.body[5].description).toContain(
+        "vélo électrique ou d'occasion",
+      );
+      expect(response.body[6].libelle).toContain(
+        'Montpellier Méditerranée Métropole',
+      );
+      expect(response.body[6].description).toContain(
+        'personnes en situation de handicap',
+      );
+    });
   });
 });

--- a/test/integration/repository/aideVelo.repository.int-spec.ts
+++ b/test/integration/repository/aideVelo.repository.int-spec.ts
@@ -40,177 +40,244 @@ describe('AideVeloRepository', () => {
     'vélo . état': 'neuf',
   };
 
-  it('doit correctement calculer les aides pour une situation de base', async () => {
-    // WHEN
-    process.env.MINIATURES_URL = 'http://localhost:3000';
-    const result = await aidesVeloRepository.getSummaryVelos(baseParams);
-
-    // THEN
-    expect(result['motorisation']).toEqual([
-      {
-        collectivite: { kind: 'région', value: '11' },
-        description:
-          "La région Île-de-France subventionne l'achat d'un kit de motorisation à hauteur de 50% et jusqu'à un plafond de 200 €.",
-        libelle: 'Île-de-France Mobilités',
-        lien: 'https://www.iledefrance-mobilites.fr/le-reseau/services-de-mobilite/velo/prime-achat-velo',
-        logo: 'http://localhost:3000/logo_ile_de_france.webp',
-        montant: 200,
-        plafond: 200,
-      },
-    ]);
-
-    // Check that all aides are in Île-de-France or France
-    expectAllMatchOneOfCollectivite(result, [
-      { kind: 'pays', value: 'France' },
-      { kind: 'région', value: '11' },
-    ]);
-  });
-
-  it("doit retourner le bon montant de l'aide avec un abonnement TER à Anger ", async () => {
-    // WHEN
-    const result = await aidesVeloRepository.getSummaryVelos({
-      ...baseParams,
-      'localisation . code insee': '49007', // Angers
-      'localisation . epci': 'CU Angers Loire Métropole',
-      'localisation . département': '49',
-      'localisation . région': '52',
-      'aides . pays de la loire . abonné TER': true,
-      'revenu fiscal de référence par part . revenu de référence': 5000,
-      'vélo . prix': 100,
-    });
-
-    // THEN
-    expect(result['électrique'].length).toBe(3);
-    const aide = result['électrique'].find((aide) => {
-      if (aide.libelle === 'Région Pays de la Loire') {
-        return true;
-      }
-    });
-    expect(aide.libelle).toContain('Région Pays de la Loire');
-    expect(aide.montant).toBe(50);
-    expectAllMatchOneOfCollectivite(result, [
-      // Check that all aides are in France, Pays de la Loire or Angers
-      { kind: 'pays', value: 'France' },
-      { kind: 'région', value: '52' },
-      { kind: 'epci', value: 'CU Angers Loire Métropole', code: '244900015' },
-    ]);
-  });
-
-  it("doit retourner le bon montant de l'aide sans un abonnement TER à Anger", async () => {
-    // WHEN
-    const result = await aidesVeloRepository.getSummaryVelos({
-      ...baseParams,
-      'localisation . code insee': '49007', // Angers
-      'localisation . epci': 'CU Angers Loire Métropole',
-      'localisation . département': '49',
-      'localisation . région': '52',
-      'aides . pays de la loire . abonné TER': false,
-    });
-
-    // THEN
-    expect(result['électrique'].length).toBe(2);
-    result['électrique'].forEach((aide) => {
-      expect(aide.libelle).not.toContain('Région Pays de la Loire');
-    });
-    expectAllMatchOneOfCollectivite(result, [
-      // Check that all aides are in France, Pays de la Loire or Angers
-      { kind: 'pays', value: 'France' },
-      { kind: 'région', value: '52' },
-      { kind: 'epci', value: 'CU Angers Loire Métropole', code: '244900015' },
-    ]);
-  });
-
-  describe("Département de l'Hérault", () => {
-    it('devrait avoir une aide régionale, départementale pour une personne habitant à Cazouls-Lès-Béziers', async () => {
+  describe('getSummaryVelos', () => {
+    test('doit correctement calculer les aides pour une situation de base', () => {
       // WHEN
-      const result = await aidesVeloRepository.getSummaryVelos({
-        ...baseParams,
-        'localisation . code insee': '34069', // Cazouls-Lès-Béziers
-        'localisation . epci': 'CC la Domitienne',
-        'localisation . département': '34',
-        'localisation . région': '76',
-        'aides . pays de la loire . abonné TER': false,
-      });
+      process.env.MINIATURES_URL = 'http://localhost:3000';
+      const result = aidesVeloRepository.getSummaryVelos(baseParams);
 
       // THEN
-      expect(result['électrique'].length).toBe(4);
-      expect(result['électrique'][0].libelle).toBe('Bonus vélo');
-      expect(result['électrique'][1].libelle).toContain('Région Occitanie');
-      expect(result['électrique'][2].libelle).toContain('Département Hérault');
-      expect(result['électrique'][3].libelle).toContain(
-        'Ville de Cazouls-Lès-Béziers',
-      );
-    });
-  });
+      expect(result['motorisation']).toEqual([
+        {
+          collectivite: { kind: 'région', value: '11' },
+          description:
+            "La région Île-de-France subventionne l'achat d'un kit de motorisation à hauteur de 50% et jusqu'à un plafond de 200 €.",
+          libelle: 'Île-de-France Mobilités',
+          lien: 'https://www.iledefrance-mobilites.fr/le-reseau/services-de-mobilite/velo/prime-achat-velo',
+          logo: 'http://localhost:3000/logo_ile_de_france.webp',
+          montant: 200,
+          plafond: 200,
+        },
+      ]);
 
-  describe('Vélo adapté et personne en situation de handicap', () => {
-    it.skip('doit correctement cumuler les aides pour une personne habitant à Toulouse', async () => {
+      // Check that all aides are in Île-de-France or France
+      expectAllMatchOneOfCollectivite(result, [
+        { kind: 'pays', value: 'France' },
+        { kind: 'région', value: '11' },
+      ]);
+    });
+
+    test("doit retourner le bon montant de l'aide avec un abonnement TER à Anger ", () => {
       // WHEN
-      const result = await aidesVeloRepository.getSummaryVelos({
+      const result = aidesVeloRepository.getSummaryVelos({
         ...baseParams,
-        'localisation . code insee': '31555', // Toulouse
-        'localisation . epci': 'Toulouse Métropole',
-        'localisation . département': '31',
-        'localisation . région': '76',
-        'aides . pays de la loire . abonné TER': false,
+        'localisation . code insee': '49007', // Angers
+        'localisation . epci': 'CU Angers Loire Métropole',
+        'localisation . département': '49',
+        'localisation . région': '52',
+        'aides . pays de la loire . abonné TER': true,
+        'revenu fiscal de référence par part . revenu de référence': 5000,
+        'vélo . prix': 100,
       });
 
       // THEN
       expect(result['électrique'].length).toBe(3);
-      expect(result['électrique'][0].libelle).toBe('Bonus vélo');
-      expect(result['électrique'][1].libelle).toBe('Région Occitanie');
-      expect(result['électrique'][2].libelle).toBe('Toulouse Métropole');
-      expect(result['adapté'].length).toBe(2);
-      expect(result['adapté'][0].libelle).toBe('Bonus vélo');
-      expect(result['adapté'][1].libelle).toContain('Région Occitanie');
-      expect(result['adapté'][1].description).toContain(
-        'Bonus vélo adapté PMR',
-      );
+      const aide = result['électrique'].find((aide) => {
+        if (aide.libelle === 'Région Pays de la Loire') {
+          return true;
+        }
+      });
+      expect(aide.libelle).toContain('Région Pays de la Loire');
+      expect(aide.montant).toBe(50);
+      expectAllMatchOneOfCollectivite(result, [
+        // Check that all aides are in France, Pays de la Loire or Angers
+        { kind: 'pays', value: 'France' },
+        { kind: 'région', value: '52' },
+        { kind: 'epci', value: 'CU Angers Loire Métropole', code: '244900015' },
+      ]);
     });
 
-    it.skip('doit correctement cumuler les aides pour une personne habitant à Montpellier', async () => {
+    test("doit retourner le bon montant de l'aide sans un abonnement TER à Anger", () => {
       // WHEN
-      const result = await aidesVeloRepository.getSummaryVelos({
+      const result = aidesVeloRepository.getSummaryVelos({
         ...baseParams,
-        'localisation . code insee': '34172', // Montpellier
+        'localisation . code insee': '49007', // Angers
+        'localisation . epci': 'CU Angers Loire Métropole',
+        'localisation . département': '49',
+        'localisation . région': '52',
+        'aides . pays de la loire . abonné TER': false,
+      });
+
+      // THEN
+      expect(result['électrique'].length).toBe(2);
+      result['électrique'].forEach((aide) => {
+        expect(aide.libelle).not.toContain('Région Pays de la Loire');
+      });
+      expectAllMatchOneOfCollectivite(result, [
+        // Check that all aides are in France, Pays de la Loire or Angers
+        { kind: 'pays', value: 'France' },
+        { kind: 'région', value: '52' },
+        { kind: 'epci', value: 'CU Angers Loire Métropole', code: '244900015' },
+      ]);
+    });
+
+    describe("Département de l'Hérault", () => {
+      test('devrait avoir une aide régionale, départementale pour une personne habitant à Cazouls-Lès-Béziers', () => {
+        // WHEN
+        const result = aidesVeloRepository.getSummaryVelos({
+          ...baseParams,
+          'localisation . code insee': '34069', // Cazouls-Lès-Béziers
+          'localisation . epci': 'CC la Domitienne',
+          'localisation . département': '34',
+          'localisation . région': '76',
+          'aides . pays de la loire . abonné TER': false,
+        });
+
+        // THEN
+        expect(result['électrique'].length).toBe(4);
+        expect(result['électrique'][0].libelle).toBe('Bonus vélo');
+        expect(result['électrique'][1].libelle).toContain('Région Occitanie');
+        expect(result['électrique'][2].libelle).toContain(
+          'Département Hérault',
+        );
+        expect(result['électrique'][3].libelle).toContain(
+          'Ville de Cazouls-Lès-Béziers',
+        );
+      });
+    });
+
+    describe('Vélo adapté et personne en situation de handicap', () => {
+      test.skip('doit correctement cumuler les aides pour une personne habitant à Toulouse', () => {
+        // WHEN
+        const result = aidesVeloRepository.getSummaryVelos({
+          ...baseParams,
+          'localisation . code insee': '31555', // Toulouse
+          'localisation . epci': 'Toulouse Métropole',
+          'localisation . département': '31',
+          'localisation . région': '76',
+          'aides . pays de la loire . abonné TER': false,
+        });
+
+        // THEN
+        expect(result['électrique'].length).toBe(3);
+        expect(result['électrique'][0].libelle).toBe('Bonus vélo');
+        expect(result['électrique'][1].libelle).toBe('Région Occitanie');
+        expect(result['électrique'][2].libelle).toBe('Toulouse Métropole');
+        expect(result['adapté'].length).toBe(2);
+        expect(result['adapté'][0].libelle).toBe('Bonus vélo');
+        expect(result['adapté'][1].libelle).toContain('Région Occitanie');
+        expect(result['adapté'][1].description).toContain(
+          'Bonus vélo adapté PMR',
+        );
+      });
+
+      test.skip('doit correctement cumuler les aides pour une personne habitant à Montpellier', () => {
+        // WHEN
+        const result = aidesVeloRepository.getSummaryVelos({
+          ...baseParams,
+          'localisation . code insee': '34172', // Montpellier
+          'localisation . epci': 'Montpellier Méditerranée Métropole',
+          'localisation . département': '34',
+          'localisation . région': '76',
+          'aides . pays de la loire . abonné TER': false,
+        });
+
+        // THEN
+        expect(result['électrique'].length).toBe(3);
+        expect(result['électrique'][0].libelle).toBe('Bonus vélo');
+        expect(result['électrique'][1].libelle).toBe('Région Occitanie');
+        expect(result['électrique'][2].libelle).toBe('Toulouse Métropole');
+        expect(result['adapté'].length).toBe(3);
+        expect(result['adapté'][0].libelle).toBe('Bonus vélo');
+        expect(result['adapté'][1].libelle).toContain('Région Occitanie');
+        expect(result['adapté'][1].description).toContain(
+          'Bonus vélo adapté PMR',
+        );
+        expect(result['adapté'][2].libelle).toContain('Département Hérault');
+        expect(result['adapté'][2].description).toContain(
+          'Chèque Hérault Handi-Vélo',
+        );
+      });
+    });
+
+    test('Villefranche Agglomération Beaujolais Saône', () => {
+      // WHEN
+      const result = aidesVeloRepository.getSummaryVelos({
+        ...baseParams,
+        'localisation . code insee': '69264', // Villefranche-sur-Saône
+        'localisation . epci': 'CA Villefranche Beaujolais Saône',
+        'localisation . département': '69',
+        'localisation . région': '84',
+        'aides . pays de la loire . abonné TER': false,
+      });
+
+      // THEN
+      forEachAide(result, (aide: AideVelo) => {
+        expect(aide.montant).toBeGreaterThanOrEqual(0);
+      });
+    });
+  });
+
+  describe.only('getAllAidesIn', () => {
+    test("doit uniquement l'aide de la région Île-de-France", () => {
+      // WHEN
+      const result = aidesVeloRepository.getAllAidesIn({
+        'localisation . région': '11',
+      });
+
+      // THEN
+      expect(result.length).toBe(1);
+      expect(result[0].libelle).toEqual('Île-de-France Mobilités');
+    });
+
+    test('ne doit retourner aucunes aides pour la commune de Dijon', () => {
+      // WHEN
+      const result = aidesVeloRepository.getAllAidesIn({
+        'localisation . code insee': '21231',
+      });
+
+      // THEN
+      expect(result.length).toBe(0);
+    });
+
+    test('ne doit retourner aucunes aides pour la commune de Dijon', () => {
+      // WHEN
+      const result = aidesVeloRepository.getAllAidesIn({
+        'localisation . code insee': '21231',
+      });
+
+      // THEN
+      expect(result.length).toBe(0);
+    });
+
+    test('doit retourner toutes les aides (nationales et locales) pour la commune de Montpellier', () => {
+      // WHEN
+      const result = aidesVeloRepository.getAllAidesIn({
+        'localisation . pays': 'France',
         'localisation . epci': 'Montpellier Méditerranée Métropole',
-        'localisation . département': '34',
+        'localisation . code insee': '34172',
         'localisation . région': '76',
-        'aides . pays de la loire . abonné TER': false,
+        'localisation . département': '34',
       });
 
       // THEN
-      expect(result['électrique'].length).toBe(3);
-      expect(result['électrique'][0].libelle).toBe('Bonus vélo');
-      expect(result['électrique'][1].libelle).toBe('Région Occitanie');
-      expect(result['électrique'][2].libelle).toBe('Toulouse Métropole');
-      expect(result['adapté'].length).toBe(3);
-      expect(result['adapté'][0].libelle).toBe('Bonus vélo');
-      expect(result['adapté'][1].libelle).toContain('Région Occitanie');
-      expect(result['adapté'][1].description).toContain(
-        'Bonus vélo adapté PMR',
+      expect(result.length).toBe(7);
+      expect(result[0].libelle).toBe('Bonus vélo');
+      expect(result[1].libelle).toContain('Région Occitanie');
+      expect(result[1].description).toContain(
+        "Achat d'un vélo à assistance électrique",
       );
-      expect(result['adapté'][2].libelle).toContain('Département Hérault');
-      expect(result['adapté'][2].description).toContain(
-        'Chèque Hérault Handi-Vélo',
+      expect(result[2].libelle).toContain('Région Occitanie');
+      expect(result[2].description).toContain('Bonus vélo adapté PMR');
+      expect(result[3].libelle).toContain('Département Hérault');
+      expect(result[4].libelle).toContain('Département Hérault');
+      expect(result[4].description).toContain('Chèque Hérault Handi-Vélo');
+      expect(result[5].libelle).toContain('Montpellier Méditerranée Métropole');
+      expect(result[5].description).toContain("vélo électrique ou d'occasion");
+      expect(result[6].libelle).toContain('Montpellier Méditerranée Métropole');
+      expect(result[6].description).toContain(
+        'personnes en situation de handicap',
       );
-    });
-  });
-
-  it('Villefranche Agglomération Beaujolais Saône', async () => {
-    // WHEN
-    const result = await aidesVeloRepository.getSummaryVelos({
-      ...baseParams,
-      'localisation . code insee': '69264', // Villefranche-sur-Saône
-      'localisation . epci': 'CA Villefranche Beaujolais Saône',
-      'localisation . département': '69',
-      'localisation . région': '84',
-      'aides . pays de la loire . abonné TER': false,
-    });
-
-    // THEN
-    forEachAide(result, (aide: AideVelo) => {
-      expect(aide.montant).toBeGreaterThanOrEqual(0);
     });
   });
 });

--- a/test/integration/repository/aideVelo.repository.int-spec.ts
+++ b/test/integration/repository/aideVelo.repository.int-spec.ts
@@ -218,7 +218,7 @@ describe('AideVeloRepository', () => {
     });
   });
 
-  describe.only('getAllAidesIn', () => {
+  describe('getAllAidesIn', () => {
     test("doit uniquement l'aide de la région Île-de-France", () => {
       // WHEN
       const result = aidesVeloRepository.getAllAidesIn({


### PR DESCRIPTION
## Modifications apportées par la PR

Cette PR introduit donc une nouvelle route `/aides/recupererAidesVeloParCodeCommuneOuEPCI` permettant de récupérer la liste des aides disponibles pour dans une commune ou un EPCI.

## Contexte

Afin de pouvoir afficher les aides disponibles dans une commune ou un EPCI une première tentative a été faite. Elle consiste à lancer une simulation des aides vélos avec des valeurs arbitraires pour les paramètres (revenu de référence, prix du vélo, etc...) :

https://github.com/betagouv/agir-back/blob/80d46b330cc41bc6481a42d2fcff190439afe5a0/src/usecase/aides.usecase.ts#L205-L247

Malheureusement, cette méthode ne prend pas en compte les conditions éligibilités des aides, en effet, si les paramètres renseignés arbitrairement ne rentre pas dans ces conditions, alors l'aide ne sera pas affichée.

Heureusement, une méthode existe déjà pour récupérer la liste des aides disponibles sans calculer les conditions d'éligibilités : [`AidesVeloEngine.getAllAidesIn`](https://www.jsdocs.io/package/@betagouv/aides-velo#AidesVeloEngine.getAllAidesIn).