### PR TITLE
Ajout des nouvelles images pour les recettes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ DOSSIER D’ARCHITECTURE TECHNIQUE.md
 log.txt
 static/images
 *.txt
+
+# Bruno collections
+
+.bruno/

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ techniques et processus de développement.
 
 - [Aides vélo](./aides-velo.md)
 - [Bilan carbone](./bilan-carbone-ngc.md)
+- [Recettes](./recettes.md)
 
 ## Architecture
 

--- a/docs/cms.md
+++ b/docs/cms.md
@@ -1,7 +1,5 @@
 # Architecture et utilisation du CMS
 
-TODO
-
 ## Architecture
 
 ## Gestion des images

--- a/docs/recettes.md
+++ b/docs/recettes.md
@@ -1,0 +1,23 @@
+# Recettes
+
+## Données
+
+Les recettes proviennet d'un
+[dump](../src/infrastructure/repository/services_recherche/recettes/data/dump-recipes.2024-09-06.json]
+JSON des données de mangerbouger.fr.
+
+## Images
+
+Les images associées à chaque recettes ont été récupérées en partie depuis le
+site de mangerbouger.fr afin d'être retéléchargées depuis shutterstock.com avec
+la bonne licence. Elles sont disponibles dans le dossier
+`Produit/Services/Recettes Manger Bouger/Shutterstock - images téléchargées` du
+drive.
+
+Elles ont été ensuite redimensionnées et converties au format WebP avant d'être
+uploadées dans le dossier `services/recettes` de cloudinary.com. C'est le lien
+vers ces images qui est utilisé dans le champ `image_url` du payload des
+recettes. A noter, que le champ `fallback_image_url` redirige vers les SVGs qui
+étaient utilisés avant.
+
+Le nom utilisé correspond au `slug` de la recette.

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@types/supertest": "^2.0.16",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
+        "cloudinary": "^2.6.0",
         "dotenv-cli": "7.2.1",
         "eslint": "^8.0.1",
         "eslint-config-prettier": "^8.3.0",
@@ -6137,6 +6138,20 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cloudinary": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-2.6.0.tgz",
+      "integrity": "sha512-FIlny9RR5LPgkMioG4V7yUpC6ASyIFQMWfx4TgOi/xBeLxJTegbyQc3itiXL0b0lDlSaL0KyT2THEw6osrKqpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=9"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -11051,6 +11066,18 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
     },
     "node_modules/qs": {
       "version": "6.13.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@types/supertest": "^2.0.16",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
+    "cloudinary": "^2.6.0",
     "dotenv-cli": "7.2.1",
     "eslint": "^8.0.1",
     "eslint-config-prettier": "^8.3.0",

--- a/scripts/recipies-to-resized-wepb.mjs
+++ b/scripts/recipies-to-resized-wepb.mjs
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import { join } from 'path';
+import sharp from 'sharp';
+
+const currentPath = new URL('./', import.meta.url).pathname;
+const rootPath = join(currentPath, '../');
+
+const srcDir = join(rootPath, 'static/images/shutterstock/');
+
+const destDir = join(rootPath, 'static/images/shutterstock-webp/');
+if (fs.existsSync(destDir)) {
+  fs.rmSync(destDir, { recursive: true });
+}
+fs.mkdirSync(destDir, { recursive: true });
+
+const images = fs.readdirSync(srcDir);
+
+console.log(`[LOG] Found ${images.length} images to convert to webp`);
+
+await Promise.all(
+  images.map(async (imgName) => {
+    console.log(`[LOG] ${imgName}`);
+    const img = sharp(join(srcDir, imgName));
+    // downscale the image to a max width of 1200px
+    img.resize({ width: 1200 });
+    try {
+      const webpName = imgName.split('.')[0] + '.webp';
+      img.webp().toFile(join(destDir, webpName));
+    } catch (e) {
+      console.error(`[ERR]   ${e.message}`);
+    }
+  }),
+);

--- a/scripts/upload-to-cloudinary.mjs
+++ b/scripts/upload-to-cloudinary.mjs
@@ -1,0 +1,59 @@
+import { v2 as cloudinary } from 'cloudinary';
+import { readdirSync } from 'fs';
+
+cloudinary.config({
+  cloud_name: 'dq023imd8',
+  api_key: '523825454186795',
+  api_secret: 'XXXXX',
+  secure: true,
+});
+
+const srcDir = './static/images/shutterstock-webp/';
+
+run();
+
+async function run() {
+  const images = readdirSync(srcDir);
+
+  for (let i = 100; i < images.length; i++) {
+    const imgName = images[i];
+    console.log(`[LOG] ${imgName}`);
+    const prevName = `services/recettes/${imgName}`;
+    const newImgName = `services/recettes/${imgName.split('.')[0]}`;
+    // const prevRes =
+    await cloudinary.api
+      .resource(prevName, async (err, _) => {
+        if (err?.http_code !== 404) {
+          await cloudinary.uploader
+            .rename(
+              prevName,
+              newImgName,
+              {
+                overwrite: true,
+                resource_type: 'image',
+              },
+              (err, res) => {
+                if (err?.http_code !== 404) {
+                  console.log(`[LOG][${i}]  renamed: ${res.url}`);
+                }
+              },
+            )
+            .catch((err) =>
+              console.error(`[ERR][${i}]  rename:${err.message}`),
+            );
+        }
+      })
+      .catch((err) => console.error(`[ERR][${i}]  ressource:${err.message}`));
+  }
+
+  // return cloudinary.uploader
+  //   .upload(srcDir + imgName, {
+  //     folder: 'services/recettes',
+  //     public_id: imgName,
+  //     async: true,
+  //     overwrite: true,
+  //     resource_type: 'image',
+  //   })
+  //   .then((res) => console.log(`[LOG]   ${res.url}`))
+  //   .catch((err) => console.error(`[ERR]   ${err.message}`));
+}

--- a/src/domain/bibliotheque_services/recherche/resultatRecherche.ts
+++ b/src/domain/bibliotheque_services/recherche/resultatRecherche.ts
@@ -31,6 +31,7 @@ export class ResultatRecherche {
   id: string;
   titre: string;
   image_url?: string;
+  fallback_image_url?: string;
 
   adresse_rue?: string;
   adresse_nom_ville?: string;
@@ -74,6 +75,7 @@ export class ResultatRecherche {
     this.id = res.id;
     this.titre = res.titre;
     this.image_url = res.image_url;
+    this.fallback_image_url = res.fallback_image_url;
     this.adresse_rue = res.adresse_rue;
     this.adresse_nom_ville = res.adresse_nom_ville;
     this.adresse_code_postal = res.adresse_code_postal;

--- a/src/domain/object_store/service/BibliothequeService_v0.ts
+++ b/src/domain/object_store/service/BibliothequeService_v0.ts
@@ -1,15 +1,15 @@
-import { Versioned, Versioned_v0 } from '../versioned';
-import { ServiceRecherche } from '../../bibliotheque_services/recherche/serviceRecherche';
+import { FruitLegume } from '../../../infrastructure/service/fruits/fruitEtLegumesServiceManager';
 import { BibliothequeServices } from '../../bibliotheque_services/bibliothequeServices';
-import { ServiceRechercheID } from '../../bibliotheque_services/recherche/serviceRechercheID';
+import { FavorisRecherche } from '../../bibliotheque_services/recherche/favorisRecherche';
 import {
   EtapeRecette,
   IngredientRecette,
   ResultatRecherche,
 } from '../../bibliotheque_services/recherche/resultatRecherche';
-import { FruitLegume } from '../../../infrastructure/service/fruits/fruitEtLegumesServiceManager';
+import { ServiceRecherche } from '../../bibliotheque_services/recherche/serviceRecherche';
+import { ServiceRechercheID } from '../../bibliotheque_services/recherche/serviceRechercheID';
 import { OpenHour } from '../../bibliotheque_services/types/openHour';
-import { FavorisRecherche } from '../../bibliotheque_services/recherche/favorisRecherche';
+import { Versioned_v0 } from '../versioned';
 
 export class EtapeRecette_v0 {
   ordre: number;
@@ -46,6 +46,7 @@ export class ResultatRecherche_v0 {
   id: string;
   titre: string;
   image_url?: string;
+  fallback_image_url?: string;
 
   adresse_rue?: string;
   adresse_nom_ville?: string;
@@ -94,6 +95,7 @@ export class ResultatRecherche_v0 {
       type_plat: res.type_plat,
       distance_metres: res.distance_metres,
       image_url: res.image_url,
+      fallback_image_url: res.fallback_image_url,
       emoji: res.emoji,
       type_fruit_legume: res.type_fruit_legume,
       commitment: res.commitment,

--- a/src/infrastructure/api/rechercheServices.controller.ts
+++ b/src/infrastructure/api/rechercheServices.controller.ts
@@ -1,4 +1,14 @@
 import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import {
   ApiBearerAuth,
   ApiBody,
   ApiOkResponse,
@@ -6,31 +16,20 @@ import {
   ApiParam,
   ApiTags,
 } from '@nestjs/swagger';
-import {
-  Controller,
-  Param,
-  UseGuards,
-  Request,
-  Post,
-  Body,
-  Get,
-  Delete,
-} from '@nestjs/common';
+import { RechercheServicesUsecase } from '../../../src/usecase/rechercheServices.usecase';
+import { CategorieRecherche } from '../../domain/bibliotheque_services/recherche/categorieRecherche';
+import { FiltreRecherche } from '../../domain/bibliotheque_services/recherche/filtreRecherche';
+import { ServiceRechercheID } from '../../domain/bibliotheque_services/recherche/serviceRechercheID';
+import { ApplicationError } from '../applicationError';
 import { AuthGuard } from '../auth/guard';
 import { GenericControler } from './genericControler';
-import { RechercheServicesUsecase } from '../../../src/usecase/rechercheServices.usecase';
+import { CategoriesRechercheAPI } from './types/rechercheServices/categoriesRechercheAPI';
 import { RechercheServiceInputAPI } from './types/rechercheServices/rechercheServiceInputAPI';
-import { ServiceRechercheID } from '../../domain/bibliotheque_services/recherche/serviceRechercheID';
 import {
   ReponseRechecheAPI,
   ResultatRechercheAPI,
 } from './types/rechercheServices/resultatRecherchAPI';
-import { CategoriesRechercheAPI } from './types/rechercheServices/categoriesRechercheAPI';
-import { CategorieRecherche } from '../../domain/bibliotheque_services/recherche/categorieRecherche';
-import { FiltreRecherche } from '../../domain/bibliotheque_services/recherche/filtreRecherche';
-import { ApplicationError } from '../applicationError';
 import { ServiceRechercheAPI } from './types/rechercheServices/serviceRechercheAPI';
-import { Thematique } from '../../domain/thematique/thematique';
 
 @Controller()
 @ApiBearerAuth()

--- a/src/infrastructure/api/service.controller.ts
+++ b/src/infrastructure/api/service.controller.ts
@@ -1,31 +1,28 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
-  Post,
-  UseGuards,
-  Request,
-  Delete,
-  Query,
   Put,
+  Request,
+  UseGuards,
 } from '@nestjs/common';
 import {
-  ApiTags,
-  ApiOkResponse,
-  ApiOperation,
   ApiBearerAuth,
   ApiBody,
-  ApiQuery,
-  getSchemaPath,
   ApiExtraModels,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  getSchemaPath,
 } from '@nestjs/swagger';
-import { GenericControler } from './genericControler';
-import { AuthGuard } from '../auth/guard';
 import { ServiceUsecase } from '../../../src/usecase/service.usecase';
-import { ServiceAPI } from './types/service/serviceAPI';
-import { LinkyConfigurationAPI } from './types/service/linkyConfigurationAPI';
 import { ApplicationError } from '../applicationError';
+import { AuthGuard } from '../auth/guard';
+import { GenericControler } from './genericControler';
+import { LinkyConfigurationAPI } from './types/service/linkyConfigurationAPI';
+import { ServiceAPI } from './types/service/serviceAPI';
 
 @ApiExtraModels(LinkyConfigurationAPI)
 @Controller()

--- a/src/infrastructure/api/types/rechercheServices/resultatRecherchAPI.ts
+++ b/src/infrastructure/api/types/rechercheServices/resultatRecherchAPI.ts
@@ -1,11 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { CategorieRechercheManager } from '../../../../domain/bibliotheque_services/recherche/categorieRecherche';
 import { ResultatRecherche } from '../../../../domain/bibliotheque_services/recherche/resultatRecherche';
 import { Day } from '../../../../domain/bibliotheque_services/types/days';
 import { FruitLegume } from '../../../service/fruits/fruitEtLegumesServiceManager';
-import {
-  CategorieRecherche,
-  CategorieRechercheManager,
-} from '../../../../domain/bibliotheque_services/recherche/categorieRecherche';
 
 export class OpenHourAPI {
   @ApiProperty({ enum: Day }) jour: Day;
@@ -38,6 +35,12 @@ export class ResultatRechercheAPI {
   @ApiProperty() temps_prepa_min: number;
   @ApiProperty() distance_metres: number;
   @ApiProperty() image_url: string;
+  @ApiProperty({
+    description: 'Fallback image url in case the image_url is not available',
+    type: String,
+    required: false,
+  })
+  fallback_image_url: string | undefined;
   @ApiProperty() emoji: string;
   @ApiProperty({ enum: FruitLegume }) type_fruit_legume: FruitLegume;
 
@@ -70,6 +73,7 @@ export class ResultatRechercheAPI {
       temps_prepa_min: res.temps_prepa_min,
       distance_metres: res.distance_metres,
       image_url: res.image_url,
+      fallback_image_url: res.fallback_image_url,
       emoji: res.emoji,
       type_fruit_legume: res.type_fruit_legume,
       commitment: res.commitment,

--- a/src/infrastructure/repository/services_recherche/recettes/recettes.repository.ts
+++ b/src/infrastructure/repository/services_recherche/recettes/recettes.repository.ts
@@ -188,7 +188,10 @@ export class RecettesRepository implements FinderInterface {
           difficulty_plat: r.express === 1 ? 'Facile' : 'Intermédiaire',
           type_plat: this.mapCategoryPlat(r.recipe_category),
           temps_prepa_min: r.preparation_time,
-          image_url: this.getImageUrlFromCategorieRecette(r.recipe_category),
+          image_url: this.getImageUrlFromRecetteSlug(r.slug),
+          fallback_image_url: this.getImageUrlFromCategorieRecette(
+            r.recipe_category,
+          ),
           ingredients: this.getIngredientsRecette(r.id),
           etapes_recette: this.getEtapesRecette(r.id),
         }),
@@ -214,6 +217,11 @@ export class RecettesRepository implements FinderInterface {
       return 'https://res.cloudinary.com/dq023imd8/image/upload/v1726729974/plat_41956db95a.svg';
     return '-';
   }
+
+  private getImageUrlFromRecetteSlug(slug: string): string {
+    return `https://res.cloudinary.com/dq023imd8/image/upload/v1726729974/services/recettes/${slug}.webp`;
+  }
+
   private getIngredientsRecette(recetteId: number): IngredientRecette[] {
     const liste_raw_ingredients = this.readIngredientsRecette(recetteId);
 


### PR DESCRIPTION
Le champs `image_url` correspondant aux recettes contient à présent le lien vers l'image .webp de la recette (téléchargée depuis shutterstock, recadrée à 1200px de largeur, convertie en webp et uploadé sur cloudinary dans le dossier `services/recettes`).

J'ai rajouté le champ `fallback_image_url` qui correspond aux précédents SVG dans le cas où une image viendrait à manquer.