### PR TITLE
feat(scripts): ajout d'un script pour lister les questions du modèle NGC

### DIFF
--- a/scripts/get-publicodes-questions.mjs
+++ b/scripts/get-publicodes-questions.mjs
@@ -1,0 +1,39 @@
+import rules from '@incubateur-ademe/nosgestesclimat/public/co2-model.FR-lang.fr.json';
+import Engine from 'publicodes';
+
+const engine = new Engine(rules);
+
+const parsedRules = engine.getParsedRules();
+let nbQuestions = 0;
+
+const questions = Object.entries(parsedRules)
+  .map(([ruleName, ruleNode]) => {
+    if (ruleNode.rawNode.question && !ruleName.startsWith('futureco-data')) {
+      nbQuestions++;
+      return {
+        name: ruleName,
+        question: ruleNode.rawNode.question,
+        type:
+          'mosaique' in ruleNode.rawNode
+            ? `mosaique (${ruleNode.rawNode.mosaique.type})`
+            : engine.context.nodesTypes.get(ruleNode)?.type,
+        options: engine.getPossibilitiesFor(ruleName)?.map((pos) => ({
+          ruleName: pos.dottedName,
+          value: pos.publicodesValue,
+        })),
+      };
+    }
+  })
+  .filter(Boolean);
+
+console.log(
+  JSON.stringify(
+    {
+      questions,
+      nb_total_rules: Object.keys(parsedRules).length,
+      nb_questions: nbQuestions,
+    },
+    null,
+    2,
+  ),
+);


### PR DESCRIPTION
Script permettant de facilement récupérer les questions du modèle Publicodes NGC avec les informations sur les types attendues.

Exemple de fichier généré : [ngc-questions_avec-actions.json](https://github.com/user-attachments/files/19681416/ngc-questions_avec-actions.json)
