### PR TITLE
Mise à jour de l'API de Mes Aides Réno

### DIFF
--- a/src/infrastructure/api/mesAidesReno.controller.ts
+++ b/src/infrastructure/api/mesAidesReno.controller.ts
@@ -17,6 +17,7 @@ import {
 import { MesAidesRenoUsecase } from '../../usecase/mesAidesReno.usecase';
 import { AuthGuard } from '../auth/guard';
 import { GenericControler } from './genericControler';
+import { MesAidesRenoIframeUrlsAPI } from './types/mes_aides_reno/MesAidesRenoIframeUrlsAPI';
 import { SituationMesAidesRenoAPI } from './types/mes_aides_voiture/situationMesAidesRenoAPI';
 
 @Controller()
@@ -27,21 +28,21 @@ export class MesAidesRenoController extends GenericControler {
     super();
   }
 
-  @Get('utilisateurs/:utilisateurId/mes_aides_reno/iframe_url')
+  @Get('utilisateurs/:utilisateurId/mes_aides_reno/get_iframe_urls')
   @UseGuards(AuthGuard)
   @ApiOperation({
     summary:
       "Retourne l'url de l'iframe avec réponses pré-remplies par rapport à la situation de l'utilisateurice",
   })
   @ApiOkResponse({
-    type: String,
+    type: MesAidesRenoIframeUrlsAPI,
     description:
       "L'url de l'iframe avec les réponses pré-remplies par rapport à la situation de l'utilisateurice",
   })
   async getIframeUrl(
     @Param('utilisateurId') utilisateurId: string,
     @Request() req,
-  ): Promise<string> {
+  ): Promise<MesAidesRenoIframeUrlsAPI> {
     this.checkCallerId(req, utilisateurId);
     return await this.mesAidesRenoUsecase.getIframeUrl(utilisateurId);
   }

--- a/src/infrastructure/api/types/mes_aides_reno/MesAidesRenoIframeUrlsAPI.ts
+++ b/src/infrastructure/api/types/mes_aides_reno/MesAidesRenoIframeUrlsAPI.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MesAidesRenoIframeUrlsAPI {
+  @ApiProperty({
+    description: "Url de l'iframe avec les réponses préremplies.",
+  })
+  iframe_url: string;
+
+  @ApiProperty({
+    description:
+      "Url de l'iframe avec les réponses préremplies et répondues. C'est-à-dire que toutes les questions préremplies ne seront pas posées, à utiliser pour aller directement au résultat lorsque l'action est déjà faite.",
+  })
+  iframe_url_deja_faite: string;
+}

--- a/src/usecase/mesAidesReno.usecase.ts
+++ b/src/usecase/mesAidesReno.usecase.ts
@@ -21,18 +21,31 @@ export class MesAidesRenoUsecase {
    * Returns the URL of the Mes Aides Reno iframe with the user's information
    * prefilled based on the user's information and KYC history.
    */
-  async getIframeUrl(userId: string): Promise<string> {
+  async getIframeUrl(
+    userId: string,
+  ): Promise<{ iframe_url: string; iframe_url_deja_faite: string }> {
     const utilisateur = await this.utilisateurRepository.getById(userId, [
       Scope.kyc,
       Scope.logement,
     ]);
     if (!utilisateur) {
-      return MES_AIDES_RENO_IFRAME_SIMULATION_URL;
+      return {
+        iframe_url: MES_AIDES_RENO_IFRAME_SIMULATION_URL,
+        iframe_url_deja_faite: MES_AIDES_RENO_IFRAME_SIMULATION_URL,
+      };
     }
 
     const params = this.getInputSearchParamsFor(utilisateur);
+    const deja_faite_params = new URLSearchParams();
 
-    return `${MES_AIDES_RENO_IFRAME_SIMULATION_URL}&${params.toString()}`;
+    params.forEach((value, key) => {
+      deja_faite_params.set(key, value + '*');
+    });
+
+    return {
+      iframe_url: `${MES_AIDES_RENO_IFRAME_SIMULATION_URL}&${params.toString()}`,
+      iframe_url_deja_faite: `${MES_AIDES_RENO_IFRAME_SIMULATION_URL}&${deja_faite_params.toString()}`,
+    };
   }
 
   /**

--- a/test/integration/api/mesAidesReno.controller.int-spec.ts
+++ b/test/integration/api/mesAidesReno.controller.int-spec.ts
@@ -40,13 +40,16 @@ describe('Mes Aides Reno (API test)', () => {
     });
 
     const response = await TestUtil.GET(
-      '/utilisateurs/utilisateur-id/mes_aides_reno/iframe_url',
+      '/utilisateurs/utilisateur-id/mes_aides_reno/get_iframe_urls',
     );
 
     expect(response.status).toBe(200);
-    expect(response.text).toBe(
-      'https://mesaidesreno.beta.gouv.fr/simulation?iframe=true&DPE.actuel=2&logement.p%C3%A9riode+de+construction=%22au+moins+15+ans%22&logement.propri%C3%A9taire+occupant=oui&vous.propri%C3%A9taire.statut=%22propri%C3%A9taire%22&logement.r%C3%A9sidence+principale+propri%C3%A9taire=oui&logement.type=%22appartement%22&m%C3%A9nage.personnes=2&m%C3%A9nage.revenu=20000&m%C3%A9nage.commune=%2231555%22&m%C3%A9nage.code+r%C3%A9gion=%2276%22&m%C3%A9nage.code+d%C3%A9partement=%2231%22&m%C3%A9nage.EPCI=%22243100518%22&logement.commune=%2231555%22&logement.commune+d%C3%A9partement=%2231%22&logement.commune+r%C3%A9gion=%2276%22&logement.commune.nom=%22Toulouse%22&logement.code+postal=%2231500%22',
-    );
+    expect(response.body).toEqual({
+      iframe_url:
+        'https://mesaidesreno.beta.gouv.fr/simulation?iframe=true&DPE.actuel=2&logement.p%C3%A9riode+de+construction=%22au+moins+15+ans%22&logement.propri%C3%A9taire+occupant=oui&vous.propri%C3%A9taire.statut=%22propri%C3%A9taire%22&logement.r%C3%A9sidence+principale+propri%C3%A9taire=oui&logement.type=%22appartement%22&m%C3%A9nage.personnes=2&m%C3%A9nage.revenu=20000&m%C3%A9nage.commune=%2231555%22&m%C3%A9nage.code+r%C3%A9gion=%2276%22&m%C3%A9nage.code+d%C3%A9partement=%2231%22&m%C3%A9nage.EPCI=%22243100518%22&logement.commune=%2231555%22&logement.commune+d%C3%A9partement=%2231%22&logement.commune+r%C3%A9gion=%2276%22&logement.commune.nom=%22Toulouse%22&logement.code+postal=%2231500%22',
+      iframe_url_deja_faite:
+        'https://mesaidesreno.beta.gouv.fr/simulation?iframe=true&DPE.actuel=2*&logement.p%C3%A9riode+de+construction=%22au+moins+15+ans%22*&logement.propri%C3%A9taire+occupant=oui*&vous.propri%C3%A9taire.statut=%22propri%C3%A9taire%22*&logement.r%C3%A9sidence+principale+propri%C3%A9taire=oui*&logement.type=%22appartement%22*&m%C3%A9nage.personnes=2*&m%C3%A9nage.revenu=20000*&m%C3%A9nage.commune=%2231555%22*&m%C3%A9nage.code+r%C3%A9gion=%2276%22*&m%C3%A9nage.code+d%C3%A9partement=%2231%22*&m%C3%A9nage.EPCI=%22243100518%22*&logement.commune=%2231555%22*&logement.commune+d%C3%A9partement=%2231%22*&logement.commune+r%C3%A9gion=%2276%22*&logement.commune.nom=%22Toulouse%22*&logement.code+postal=%2231500%22*',
+    });
   });
 
   test('POST /utilisateurs/:utilisateurId/mes_aides_reno/nouvelle_situation', async () => {

--- a/test/integration/usecase/mesAidesReno.usecase.int-spec.ts
+++ b/test/integration/usecase/mesAidesReno.usecase.int-spec.ts
@@ -210,7 +210,10 @@ describe('Mes Aides Réno', () => {
   describe('getIframeUrl', () => {
     test("should return the url without params if the user doesn't exist", async () => {
       const result = await usecase.getIframeUrl('non_existant_id');
-      expect(result).toBe(
+      expect(result.iframe_url).toBe(
+        'https://mesaidesreno.beta.gouv.fr/simulation?iframe=true',
+      );
+      expect(result.iframe_url_deja_faite).toBe(
         'https://mesaidesreno.beta.gouv.fr/simulation?iframe=true',
       );
     });
@@ -241,8 +244,11 @@ describe('Mes Aides Réno', () => {
       });
 
       const result = await usecase.getIframeUrl('utilisateur-id');
-      expect(result).toBe(
+      expect(result.iframe_url).toBe(
         'https://mesaidesreno.beta.gouv.fr/simulation?iframe=true&DPE.actuel=2&logement.p%C3%A9riode+de+construction=%22au+moins+15+ans%22&logement.propri%C3%A9taire+occupant=oui&vous.propri%C3%A9taire.statut=%22propri%C3%A9taire%22&logement.r%C3%A9sidence+principale+propri%C3%A9taire=oui&logement.surface=125&logement.type=%22appartement%22&m%C3%A9nage.personnes=2&m%C3%A9nage.revenu=20000&m%C3%A9nage.commune=%2231555%22&m%C3%A9nage.code+r%C3%A9gion=%2276%22&m%C3%A9nage.code+d%C3%A9partement=%2231%22&m%C3%A9nage.EPCI=%22243100518%22&logement.commune=%2231555%22&logement.commune+d%C3%A9partement=%2231%22&logement.commune+r%C3%A9gion=%2276%22&logement.commune.nom=%22Toulouse%22&logement.code+postal=%2231500%22',
+      );
+      expect(result.iframe_url_deja_faite).toBe(
+        'https://mesaidesreno.beta.gouv.fr/simulation?iframe=true&DPE.actuel=2*&logement.p%C3%A9riode+de+construction=%22au+moins+15+ans%22*&logement.propri%C3%A9taire+occupant=oui*&vous.propri%C3%A9taire.statut=%22propri%C3%A9taire%22*&logement.r%C3%A9sidence+principale+propri%C3%A9taire=oui*&logement.surface=125*&logement.type=%22appartement%22*&m%C3%A9nage.personnes=2*&m%C3%A9nage.revenu=20000*&m%C3%A9nage.commune=%2231555%22*&m%C3%A9nage.code+r%C3%A9gion=%2276%22*&m%C3%A9nage.code+d%C3%A9partement=%2231%22*&m%C3%A9nage.EPCI=%22243100518%22*&logement.commune=%2231555%22*&logement.commune+d%C3%A9partement=%2231%22*&logement.commune+r%C3%A9gion=%2276%22*&logement.commune.nom=%22Toulouse%22*&logement.code+postal=%2231500%22*',
       );
     });
 
@@ -286,8 +292,11 @@ describe('Mes Aides Réno', () => {
       utilisateur.kyc_history.updateQuestion(kyc);
 
       const result = await usecase.getIframeUrl('utilisateur-id');
-      expect(result).toBe(
+      expect(result.iframe_url).toBe(
         'https://mesaidesreno.beta.gouv.fr/simulation?iframe=true&DPE.actuel=2&logement.p%C3%A9riode+de+construction=%22au+moins+15+ans%22&logement.propri%C3%A9taire+occupant=oui&vous.propri%C3%A9taire.statut=%22propri%C3%A9taire%22&logement.r%C3%A9sidence+principale+propri%C3%A9taire=oui&logement.surface=50&logement.type=%22appartement%22&m%C3%A9nage.personnes=2&m%C3%A9nage.revenu=20000&m%C3%A9nage.commune=%2231555%22&m%C3%A9nage.code+r%C3%A9gion=%2276%22&m%C3%A9nage.code+d%C3%A9partement=%2231%22&m%C3%A9nage.EPCI=%22243100518%22&logement.commune=%2231555%22&logement.commune+d%C3%A9partement=%2231%22&logement.commune+r%C3%A9gion=%2276%22&logement.commune.nom=%22Toulouse%22&logement.code+postal=%2231500%22',
+      );
+      expect(result.iframe_url_deja_faite).toBe(
+        'https://mesaidesreno.beta.gouv.fr/simulation?iframe=true&DPE.actuel=2*&logement.p%C3%A9riode+de+construction=%22au+moins+15+ans%22*&logement.propri%C3%A9taire+occupant=oui*&vous.propri%C3%A9taire.statut=%22propri%C3%A9taire%22*&logement.r%C3%A9sidence+principale+propri%C3%A9taire=oui*&logement.surface=50*&logement.type=%22appartement%22*&m%C3%A9nage.personnes=2*&m%C3%A9nage.revenu=20000*&m%C3%A9nage.commune=%2231555%22*&m%C3%A9nage.code+r%C3%A9gion=%2276%22*&m%C3%A9nage.code+d%C3%A9partement=%2231%22*&m%C3%A9nage.EPCI=%22243100518%22*&logement.commune=%2231555%22*&logement.commune+d%C3%A9partement=%2231%22*&logement.commune+r%C3%A9gion=%2276%22*&logement.commune.nom=%22Toulouse%22*&logement.code+postal=%2231500%22*',
       );
     });
 
@@ -317,8 +326,11 @@ describe('Mes Aides Réno', () => {
       });
 
       const result = await usecase.getIframeUrl('utilisateur-id');
-      expect(result).toBe(
+      expect(result.iframe_url).toBe(
         'https://mesaidesreno.beta.gouv.fr/simulation?iframe=true&DPE.actuel=2&logement.propri%C3%A9taire+occupant=oui&vous.propri%C3%A9taire.statut=%22propri%C3%A9taire%22&logement.r%C3%A9sidence+principale+propri%C3%A9taire=oui&m%C3%A9nage.personnes=2&m%C3%A9nage.revenu=20000',
+      );
+      expect(result.iframe_url_deja_faite).toBe(
+        'https://mesaidesreno.beta.gouv.fr/simulation?iframe=true&DPE.actuel=2*&logement.propri%C3%A9taire+occupant=oui*&vous.propri%C3%A9taire.statut=%22propri%C3%A9taire%22*&logement.r%C3%A9sidence+principale+propri%C3%A9taire=oui*&m%C3%A9nage.personnes=2*&m%C3%A9nage.revenu=20000*',
       );
     });
   });


### PR DESCRIPTION
La route `mes_aides_reno/iframe_url` devient `mes_aides_reno/get_iframe_urls` et renvoie un objet avec une nouvelle url permettant de skip les questions déjà répondues au lieu de simplement les préremplir. Ce qui permet de pouvoir aller directement aux résultats lorsque l'action correspondante est déjà faite.