### PR TITLE
fix(aides_velo): récupère correctement le code_insee de la commune

### DIFF
--- a/src/infrastructure/repository/commune/commune.repository.ts
+++ b/src/infrastructure/repository/commune/commune.repository.ts
@@ -298,6 +298,8 @@ export class CommuneRepository {
     return null;
   }
 
+  // FIXME: the [utilisateur.logement.commune] doesn't correspond anymore to the
+  // "commune" field in `_codes_postaux`.
   getCommuneCodeInsee(code_postal: string, nom_commune: string): string | null {
     const liste: CommuneParCodePostal[] = _codes_postaux[code_postal];
     if (!liste) {


### PR DESCRIPTION
La représentation de l'attribut `logement.commune` ne correspond plus à celui de `code_postaux.json` utilisé par le `CommuneRepository`.