### PR TITLE
feat: amélioration du typechecking des codes des KYC à choix

### DIFF
--- a/src/domain/kyc/KYCID.ts
+++ b/src/domain/kyc/KYCID.ts
@@ -1,3 +1,8 @@
+/**
+ * NOTE: le mapping avec les valeur associées pour les réponses des KYCs à
+ * choix, sont définies dans 'src/domain/kyc/publicodesMapping.ts' et permet
+ * d'avoir un typechecking plus fort pour la manipulation des réponses KYC.
+ */
 export enum KYCID {
   _1 = '_1',
   _2 = '_2',

--- a/src/domain/kyc/kycHistory.ts
+++ b/src/domain/kyc/kycHistory.ts
@@ -2,6 +2,7 @@ import { Categorie } from '../contenu/categorie';
 import { KYCHistory_v2 } from '../object_store/kyc/kycHistory_v2';
 import { Thematique } from '../thematique/thematique';
 import { KycDefinition } from './kycDefinition';
+import { KYCID } from './KYCID';
 import { KYCMosaicID, MosaicCatalogue } from './mosaicDefinition';
 import { MosaicKYCDef } from './mosaicKYC';
 import { QuestionChoix } from './new_interfaces/QuestionChoix';
@@ -14,8 +15,8 @@ import { AndConditionSet, QuestionKYC } from './questionKYC';
 
 export type AnyQuestion =
   | QuestionKYC
-  | QuestionChoixMultiple
-  | QuestionChoixUnique
+  | QuestionChoixMultiple<KYCID>
+  | QuestionChoixUnique<KYCID>
   | QuestionSimple
   | QuestionNumerique
   | QuestionTexteLibre;
@@ -66,19 +67,25 @@ export class KYCHistory {
     return undefined;
   }
 
-  public getQuestionChoixUnique(code: string): QuestionChoixUnique {
+  public getQuestionChoixUnique<ID extends KYCID>(
+    code: ID,
+  ): QuestionChoixUnique<ID> | undefined {
     const kyc = this.getQuestion(code);
     if (kyc) return new QuestionChoixUnique(kyc);
     return undefined;
   }
 
-  public getQuestionChoixMultiple(code: string): QuestionChoixMultiple {
+  public getQuestionChoixMultiple<ID extends KYCID>(
+    code: ID,
+  ): QuestionChoixMultiple<ID> | undefined {
     const kyc = this.getQuestion(code);
     if (kyc) return new QuestionChoixMultiple(kyc);
     return undefined;
   }
 
-  public getQuestionChoix(code: string): QuestionChoix {
+  public getQuestionChoix<ID extends KYCID>(
+    code: ID,
+  ): QuestionChoix<ID> | undefined {
     const kyc = this.getQuestion(code);
     if (kyc) return new QuestionChoix(kyc);
     return undefined;
@@ -449,8 +456,11 @@ export class KYCHistory {
     return or_result;
   }
 
-  public doesQuestionExistsByCode(code_question: string) {
-    return !!code_question && this.getKYCDefinitionByCodeOrNull(code_question);
+  public doesQuestionExistsByCode(code_question: KYCID): boolean {
+    return (
+      !!code_question &&
+      this.getKYCDefinitionByCodeOrNull(code_question) != null
+    );
   }
 
   private getAnsweredQuestionByIdCMS(id_cms: number): QuestionKYC {

--- a/src/domain/kyc/new_interfaces/QuestionChoix.ts
+++ b/src/domain/kyc/new_interfaces/QuestionChoix.ts
@@ -1,6 +1,8 @@
+import { KYCID } from '../KYCID';
+import { KYCComplexValues } from '../publicodesMapping';
 import { QuestionKYC } from '../questionKYC';
 
-export class QuestionChoix {
+export class QuestionChoix<ID extends KYCID> {
   protected kyc: QuestionKYC;
 
   constructor(kyc: QuestionKYC) {
@@ -18,16 +20,17 @@ export class QuestionChoix {
     return this.kyc.is_answered;
   }
 
-  public isSelected(code_reponse: string): boolean {
+  public isSelected(code_reponse: KYCComplexValues[ID]['code']): boolean {
     const entry_liste = this.kyc.reponse_complexe;
     const found = entry_liste.find((r) => r.code === code_reponse);
     return found ? found.selected : false;
   }
 
-  public getAllCodes(): string[] {
+  public getAllCodes(): KYCComplexValues[ID]['code'][] {
     return this.kyc.reponse_complexe.map((r) => r.code);
   }
-  public getSelectedCodes(): string[] {
+
+  public getSelectedCodes(): KYCComplexValues[ID]['code'][] {
     if (!this.kyc.reponse_complexe) return [];
     const result = [];
     for (const rep of this.kyc.reponse_complexe) {
@@ -37,6 +40,7 @@ export class QuestionChoix {
     }
     return result;
   }
+
   public getNombreSelections() {
     if (!this.kyc.reponse_complexe) return 0;
     const entry_liste = this.kyc.reponse_complexe;

--- a/src/domain/kyc/new_interfaces/QuestionChoixMultiples.ts
+++ b/src/domain/kyc/new_interfaces/QuestionChoixMultiples.ts
@@ -1,21 +1,25 @@
+import { KYCID } from '../KYCID';
+import { KYCComplexValues } from '../publicodesMapping';
 import { QuestionKYC } from '../questionKYC';
 import { QuestionChoix } from './QuestionChoix';
 
-export class QuestionChoixMultiple extends QuestionChoix {
+export class QuestionChoixMultiple<ID extends KYCID> extends QuestionChoix<ID> {
   constructor(kyc: QuestionKYC) {
     super(kyc);
   }
 
-  public select(code: string) {
+  public select(code: KYCComplexValues[ID]['code']) {
     this.setCodeState(code, true);
   }
-  public deselect(code: string) {
+
+  public deselect(code: KYCComplexValues[ID]['code']) {
     this.setCodeState(code, false);
   }
 
-  public setCodeState(code: string, selected: boolean) {
+  public setCodeState(code: KYCComplexValues[ID]['code'], selected: boolean) {
     this.kyc.touch();
     const entry_liste = this.kyc.reponse_complexe;
+
     for (const entry of entry_liste) {
       if (entry.code === code) {
         entry.selected = selected;
@@ -23,9 +27,11 @@ export class QuestionChoixMultiple extends QuestionChoix {
       }
     }
   }
+
   public deselectAll() {
     this.kyc.touch();
     const entry_liste = this.kyc.reponse_complexe;
+
     for (const entry of entry_liste) {
       entry.selected = false;
     }

--- a/src/domain/kyc/new_interfaces/QuestionChoixUnique.ts
+++ b/src/domain/kyc/new_interfaces/QuestionChoixUnique.ts
@@ -1,21 +1,23 @@
+import { KYCID } from '../KYCID';
+import { KYCComplexValues } from '../publicodesMapping';
 import { QuestionKYC } from '../questionKYC';
 import { KYCReponseComplexe } from '../QuestionKYCData';
 import { QuestionChoix } from './QuestionChoix';
 
-export class QuestionChoixUnique extends QuestionChoix {
+export class QuestionChoixUnique<ID extends KYCID> extends QuestionChoix<ID> {
   constructor(kyc: QuestionKYC) {
     super(kyc);
   }
 
-  public getSelectedCode(): string {
+  public getSelectedCode(): KYCComplexValues[ID]['code'] {
     return this.kyc.getSelectedCode();
   }
 
-  public getSelectedNgcCode(): string {
+  public getSelectedNgcCode(): KYCComplexValues[ID]['ngc_code'] {
     return this.kyc.getSelectedNgcCode();
   }
 
-  public selectByCode(code: string) {
+  public selectByCode(code: KYCComplexValues[ID]['code']): void {
     if (!this.kyc.reponse_complexe) return;
     this.kyc.touch();
     for (const rep of this.kyc.reponse_complexe) {
@@ -23,7 +25,7 @@ export class QuestionChoixUnique extends QuestionChoix {
     }
   }
 
-  public selectByCodeNgc(code_ngc: string): boolean {
+  public selectByCodeNgc(code_ngc: KYCComplexValues[ID]['ngc_code']): boolean {
     this.kyc.touch();
     const code = this.getCodeByNGCCode(code_ngc);
     if (code) {
@@ -33,7 +35,9 @@ export class QuestionChoixUnique extends QuestionChoix {
     return false;
   }
 
-  private getCodeByNGCCode(ngc_code: string): string {
+  private getCodeByNGCCode(
+    ngc_code: KYCComplexValues[ID]['ngc_code'],
+  ): KYCComplexValues[ID]['code'] | null {
     if (!this.kyc.reponse_complexe) {
       return null;
     }
@@ -41,7 +45,9 @@ export class QuestionChoixUnique extends QuestionChoix {
     return q ? q.code : null;
   }
 
-  private getQuestionComplexeByNgcCode(ngc_code: string): KYCReponseComplexe {
+  private getQuestionComplexeByNgcCode(
+    ngc_code: KYCComplexValues[ID]['ngc_code'],
+  ): KYCReponseComplexe | null {
     if (!this.kyc.reponse_complexe) return null;
     return this.kyc.reponse_complexe.find((r) => r.ngc_code === ngc_code);
   }

--- a/src/domain/kyc/publicodesMapping.ts
+++ b/src/domain/kyc/publicodesMapping.ts
@@ -15,9 +15,63 @@ export type KYCComplexValues = {
   [key in KYCID]: { code: string; ngc_code?: string };
 } & {
   _default: { code: string; ngc_code?: string };
+  [KYCID.KYC001]: {
+    code:
+      | 'alimentation'
+      | 'climat'
+      | 'consommation'
+      | 'dechet'
+      | 'logement'
+      | 'loisir'
+      | 'transport'
+      | 'rien';
+  };
+  [KYCID.KYC002]: {
+    code: 'marcher' | 'faire_velo' | 'TEC' | 'co_voit' | 'voiture' | 'aucun';
+  };
+  [KYCID.KYC003]: {
+    code: BooleanKYC.oui | BooleanKYC.non;
+  };
+  [KYCID.KYC004]: {
+    code:
+      | 'pistes_cyclables_faciles'
+      | 'pistes_cyclables_dangereuses'
+      | 'absence_pistes_cyclables'
+      | 'ne_sais_pas';
+  };
+  [KYCID.KYC005]: {
+    code: 'emploi' | 'sans_emploi' | 'etudiant' | 'retraite' | 'ne_sais_pas';
+  };
+  [KYCID.KYC006]: { code: 'plus_15' | 'moins_15' };
+  [KYCID.KYC007]: {
+    code: 'cafe' | 'the' | 'chicore' | 'autre' | 'aucune';
+  };
+  [KYCID.KYC008]: {
+    code: 'max_tele' | 'un_peu_tele' | 'no_tele' | 'ne_sais_pas';
+  };
   [KYCID.KYC009]: {
     code: 'ma_voit' | 'loc_voit' | 'co_voit' | 'pas_voiture';
-    ngc_code: undefined;
+  };
+  [KYCID.KYC010]: {
+    code: BooleanKYC.oui | BooleanKYC.non;
+  };
+  [KYCID.KYC011]: {
+    code: 'voit_therm' | 'voit_elec_hybride' | 'pas_voiture' | 'ne_sais_pas';
+  };
+  [KYCID.KYC012]: {
+    code: BooleanKYC.oui | BooleanKYC.non | 'ne_sais_pas';
+  };
+  [KYCID.KYC013]: {
+    code:
+      | 'limiter_impact'
+      | 'achat_voit'
+      | 'economie'
+      | 'bouger'
+      | 'autre'
+      | 'ne_sais_pas';
+  };
+  [KYCID.KYC_alimentation_regime]: {
+    code: 'chaque_jour_viande' | 'peu_viande' | 'vegetarien' | 'vegetalien';
   };
   [KYCID.KYC_transport_type_utilisateur]:
     | { code: 'proprio'; ngc_code: "'propriétaire'" }
@@ -55,9 +109,55 @@ export type KYCComplexValues = {
     | { code: 'parfois'; ngc_code: "'parfois'" }
     | { code: 'souvent'; ngc_code: "'souvent'" }
     | { code: 'toujours'; ngc_code: "'oui toujours'" };
-  [KYCID.KYC_possede_voiture_oui_non]:
-    | { code: BooleanKYC.oui; ngc_code: 'oui' }
-    | { code: BooleanKYC.non; ngc_code: 'non' };
+  [KYCID.KYC_possede_voiture_oui_non]: {
+    code: BooleanKYC.oui | BooleanKYC.non;
+  };
+  [KYCID.KYC_chauffage_gaz]:
+    | {
+        code: BooleanKYC.oui;
+        ngc_code: 'oui';
+      }
+    | {
+        code: BooleanKYC.non;
+        ngc_code: 'non';
+      }
+    | { code: 'ne_sais_pas' };
+  [KYCID.KYC_chauffage_fioul]:
+    | {
+        code: BooleanKYC.oui;
+        ngc_code: 'oui';
+      }
+    | {
+        code: BooleanKYC.non;
+        ngc_code: 'non';
+      }
+    | { code: 'ne_sais_pas' };
+  [KYCID.KYC_chauffage_bois]:
+    | {
+        code: BooleanKYC.oui;
+        ngc_code: 'oui';
+      }
+    | {
+        code: BooleanKYC.non;
+        ngc_code: 'non';
+      }
+    | { code: 'ne_sais_pas' };
+  [KYCID.KYC_chauffage_elec]:
+    | {
+        code: BooleanKYC.oui;
+        ngc_code: 'oui';
+      }
+    | {
+        code: BooleanKYC.non;
+        ngc_code: 'non';
+      }
+    | { code: 'ne_sais_pas' };
+  [KYCID.KYC_type_logement]:
+    | { code: 'type_maison'; ngc_code: "'maison'" }
+    | { code: 'type_appartement'; ngc_code: "'appartement'" };
+  [KYCID.KYC_DPE]: {
+    code: 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'ne_sais_pas';
+  };
 };
 
 // NOTE: sûrement à déplacer dans un fichier dédié

--- a/src/domain/kyc/synchro/kycRegimeToKycRepasSynch.ts
+++ b/src/domain/kyc/synchro/kycRegimeToKycRepasSynch.ts
@@ -4,7 +4,7 @@ import { QuestionChoixUnique } from '../new_interfaces/QuestionChoixUnique';
 
 export class KycRegimeToKycRepas {
   public static synchroAlimentationRegime(
-    kyc_regime: QuestionChoixUnique,
+    kyc_regime: QuestionChoixUnique<KYCID.KYC_alimentation_regime>,
     utilisateur: Utilisateur,
   ) {
     const code = kyc_regime.getSelectedCode();

--- a/src/domain/kyc/synchro/kycToProfileSync.ts
+++ b/src/domain/kyc/synchro/kycToProfileSync.ts
@@ -16,9 +16,9 @@ export class KycToProfileSync {
 
     switch (kyc.code) {
       case KYCID.KYC006:
-        utilisateur.logement.plus_de_15_ans = new QuestionChoix(kyc).isSelected(
-          'plus_15',
-        );
+        utilisateur.logement.plus_de_15_ans = new QuestionChoix<KYCID.KYC006>(
+          kyc,
+        ).isSelected('plus_15');
         break;
       case KYCID.KYC_logement_age:
         const value = new QuestionNumerique(kyc).getValue();

--- a/src/domain/kyc/synchro/logementToKycSync.ts
+++ b/src/domain/kyc/synchro/logementToKycSync.ts
@@ -55,7 +55,7 @@ export class LogementToKycSync {
       history.updateQuestion(choix_unique);
     }
     if (input.chauffage) {
-      const target_KYC: Record<Chauffage, string> = {
+      const target_KYC: Record<Chauffage, KYCID> = {
         gaz: KYCID.KYC_chauffage_gaz,
         fioul: KYCID.KYC_chauffage_fioul,
         electricite: KYCID.KYC_chauffage_elec,

--- a/src/domain/scoring/system_v2/kycToTagsV2.ts
+++ b/src/domain/scoring/system_v2/kycToTagsV2.ts
@@ -217,7 +217,7 @@ export class KycToTags_v2 {
         }
       }
       if (mappers.distribute) {
-        for (const [code, tag] of Object.entries(mappers.distribute)) {
+        for (const [_, tag] of Object.entries(mappers.distribute)) {
           tag_set.add(tag);
         }
       }
@@ -360,7 +360,7 @@ export class KycToTags_v2 {
     profile.replaceAllTags(this.new_tag_set);
   }
 
-  private is_code(kyc_code: string, code: string): boolean {
+  private is_code(kyc_code: KYCID, code: string): boolean {
     const kyc = this.hist.getQuestionChoix(kyc_code);
     if (!kyc) return false;
     return kyc.isSelected(code);
@@ -402,7 +402,7 @@ export class KycToTags_v2 {
     }
   }
 
-  private has_one_of(kyc_code: string, code_liste: string[]): boolean {
+  private has_one_of(kyc_code: KYCID, code_liste: string[]): boolean {
     const kyc = this.hist.getQuestionChoix(kyc_code);
     if (!kyc) return false;
     for (const code of code_liste) {

--- a/src/domain/scoring/userTagEvaluator.ts
+++ b/src/domain/scoring/userTagEvaluator.ts
@@ -16,7 +16,10 @@ export class UserTagEvaluator {
     }
   }
 
-  private static kyc_001(user: Utilisateur, kyc: QuestionChoixMultiple) {
+  private static kyc_001(
+    user: Utilisateur,
+    kyc: QuestionChoixMultiple<KYCID.KYC001>,
+  ) {
     user.increaseTagValueIfElse(
       Tag.transport,
       kyc.isSelected(Thematique.transport),
@@ -61,7 +64,10 @@ export class UserTagEvaluator {
     );
   }
 
-  private static kyc_002(user: Utilisateur, kyc: QuestionChoixMultiple) {
+  private static kyc_002(
+    user: Utilisateur,
+    kyc: QuestionChoixMultiple<KYCID.KYC002>,
+  ) {
     user.increaseTagValueIfElse(
       Tag.appetence_covoit,
       kyc.isSelected('co_voit'),
@@ -88,7 +94,10 @@ export class UserTagEvaluator {
     );
   }
 
-  private static kyc_003(user: Utilisateur, kyc: QuestionChoixUnique) {
+  private static kyc_003(
+    user: Utilisateur,
+    kyc: QuestionChoixUnique<KYCID.KYC003>,
+  ) {
     user.increaseTagValueIfElse(
       Tag.possede_velo,
       kyc.isSelected(BooleanKYC.oui),
@@ -97,7 +106,10 @@ export class UserTagEvaluator {
     );
   }
 
-  private static kyc_004(user: Utilisateur, kyc: QuestionChoixUnique) {
+  private static kyc_004(
+    user: Utilisateur,
+    kyc: QuestionChoixUnique<KYCID.KYC004>,
+  ) {
     user.increaseTagForAnswers(Tag.pistes_cyclables, kyc, {
       pistes_cyclables_faciles: 100,
       pistes_cyclables_dangereuses: 50,
@@ -106,15 +118,23 @@ export class UserTagEvaluator {
     });
   }
 
-  private static kyc_005(user: Utilisateur, kyc: QuestionChoixUnique) {
+  private static kyc_005(
+    user: Utilisateur,
+    kyc: QuestionChoixUnique<KYCID.KYC005>,
+  ) {
     user.increaseTagForAnswers(Tag.possede_emploi, kyc, {
       emploi: 100,
       sans_emploi: -100,
+      etudiant: 0,
+      retraite: 0,
       ne_sais_pas: 0,
     });
   }
 
-  private static kyc_006(user: Utilisateur, kyc: QuestionChoixUnique) {
+  private static kyc_006(
+    user: Utilisateur,
+    kyc: QuestionChoixUnique<KYCID.KYC006>,
+  ) {
     user.increaseTagValueIfElse(
       Tag.logement_plus_15_ans,
       kyc.isSelected('plus_15'),
@@ -122,6 +142,7 @@ export class UserTagEvaluator {
       -100,
     );
   }
+
   private static kyc_logement_age(user: Utilisateur, kyc: QuestionNumerique) {
     const value = kyc.getValue();
     if (value) {
@@ -134,7 +155,10 @@ export class UserTagEvaluator {
     }
   }
 
-  private static kyc_007(user: Utilisateur, kyc: QuestionChoixMultiple) {
+  private static kyc_007(
+    user: Utilisateur,
+    kyc: QuestionChoixMultiple<KYCID.KYC007>,
+  ) {
     user.increaseTagValueIfElse(
       Tag.appetence_cafe,
       kyc.isSelected('cafe'),
@@ -143,7 +167,10 @@ export class UserTagEvaluator {
     );
   }
 
-  private static kyc_008(user: Utilisateur, kyc: QuestionChoixUnique) {
+  private static kyc_008(
+    user: Utilisateur,
+    kyc: QuestionChoixUnique<KYCID.KYC008>,
+  ) {
     user.increaseTagForAnswers(Tag.capacite_teletravail, kyc, {
       max_tele: 100,
       un_peu_tele: 50,
@@ -152,7 +179,10 @@ export class UserTagEvaluator {
     });
   }
 
-  private static kyc_009(user: Utilisateur, kyc: QuestionChoixUnique) {
+  private static kyc_009(
+    user: Utilisateur,
+    kyc: QuestionChoixUnique<KYCID.KYC009>,
+  ) {
     user.increaseTagValueIfElse(
       Tag.possede_voiture,
       kyc.isSelected('ma_voit'),
@@ -167,7 +197,10 @@ export class UserTagEvaluator {
     );
   }
 
-  private static kyc_010(user: Utilisateur, kyc: QuestionChoixUnique) {
+  private static kyc_010(
+    user: Utilisateur,
+    kyc: QuestionChoixUnique<KYCID.KYC010>,
+  ) {
     user.increaseTagValueIfElse(
       Tag.possede_jardin,
       kyc.isSelected(BooleanKYC.oui),
@@ -176,7 +209,10 @@ export class UserTagEvaluator {
     );
   }
 
-  private static kyc_011(user: Utilisateur, kyc: QuestionChoixUnique) {
+  private static kyc_011(
+    user: Utilisateur,
+    kyc: QuestionChoixUnique<KYCID.KYC011>,
+  ) {
     user.increaseTagValueIfElse(
       Tag.possede_voiture_thermique,
       kyc.isSelected('voit_therm'),
@@ -191,7 +227,10 @@ export class UserTagEvaluator {
     );
   }
 
-  private static kyc_012(user: Utilisateur, kyc: QuestionChoixUnique) {
+  private static kyc_012(
+    user: Utilisateur,
+    kyc: QuestionChoixUnique<KYCID.KYC012>,
+  ) {
     user.increaseTagValueIfElse(
       Tag.trajet_court_voiture,
       kyc.isSelected(BooleanKYC.oui),
@@ -206,7 +245,10 @@ export class UserTagEvaluator {
     );
   }
 
-  private static kyc_013(user: Utilisateur, kyc: QuestionChoixMultiple) {
+  private static kyc_013(
+    user: Utilisateur,
+    kyc: QuestionChoixMultiple<KYCID.KYC013>,
+  ) {
     user.increaseTagValueIfElse(
       Tag.appetence_limiter_impact_trajets,
       kyc.isSelected('limiter_impact'),

--- a/src/domain/utilisateur/utilisateur.ts
+++ b/src/domain/utilisateur/utilisateur.ts
@@ -7,7 +7,9 @@ import { CacheBilanCarbone } from '../bilan/cacheBilanCarbone';
 import { Gamification } from '../gamification/gamification';
 import { History } from '../history/history';
 import { KYCHistory } from '../kyc/kycHistory';
+import { KYCID } from '../kyc/KYCID';
 import { QuestionChoixUnique } from '../kyc/new_interfaces/QuestionChoixUnique';
+import { KYCComplexValues } from '../kyc/publicodesMapping';
 import { Logement } from '../logement/logement';
 import { NotificationHistory } from '../notification/notificationHistory';
 import { ProfileRecommandationUtilisateur } from '../scoring/system_v2/profileRecommandationUtilisateur';
@@ -362,10 +364,11 @@ export class Utilisateur extends UtilisateurData {
   public increaseTagValue(tag: Tag, value: number) {
     this.setTagValue(tag, this.getTagValue(tag) + value);
   }
-  public increaseTagForAnswers(
+
+  public increaseTagForAnswers<ID extends KYCID>(
     tag: Tag,
-    kyc: QuestionChoixUnique,
-    map: Record<string, number>,
+    kyc: QuestionChoixUnique<ID>,
+    map: Record<KYCComplexValues[ID]['code'], number>,
   ) {
     if (kyc && kyc.isAnswered()) {
       for (const key in map) {

--- a/src/usecase/mesAidesReno.usecase.ts
+++ b/src/usecase/mesAidesReno.usecase.ts
@@ -389,7 +389,7 @@ export class MesAidesRenoUsecase {
               const kyc = utilisateur.kyc_history.getQuestionChoixUnique(
                 KYCID.KYC_type_logement,
               );
-              kyc.selectByCode(TypeLogement.maison);
+              kyc.selectByCode('type_maison');
               utilisateur.kyc_history.updateQuestion(kyc);
               return kyc.getKyc();
             }
@@ -397,7 +397,7 @@ export class MesAidesRenoUsecase {
               const kyc = utilisateur.kyc_history.getQuestionChoixUnique(
                 KYCID.KYC_type_logement,
               );
-              kyc.selectByCode(TypeLogement.appartement);
+              kyc.selectByCode('type_appartement');
               utilisateur.kyc_history.updateQuestion(kyc);
               return kyc.getKyc();
             }

--- a/src/usecase/migration.usescase.ts
+++ b/src/usecase/migration.usescase.ts
@@ -562,7 +562,11 @@ export class MigrationUsecase {
     // DO SOMETHING
 
     const kyc = utilisateur.kyc_history.getQuestionChoixUnique(kycId);
-    if (kyc && kyc.isSelected('hybride')) {
+    if (
+      kyc &&
+      // @ts-ignore
+      kyc.isSelected('hybride')
+    ) {
       kyc.selectByCode('hybride_non_rechargeable');
       utilisateur.kyc_history.updateQuestion(kyc);
     }

--- a/src/usecase/questionKYC.usecase.ts
+++ b/src/usecase/questionKYC.usecase.ts
@@ -365,8 +365,9 @@ export class QuestionKYCUsecase {
 
     kyc.setStringValue(input);
   }
-  private updateQuestionChoixUnique(
-    kyc: QuestionChoixUnique,
+
+  private updateQuestionChoixUnique<ID extends KYCID>(
+    kyc: QuestionChoixUnique<ID>,
     input_reponse_payload: {
       code?: string;
       value?: string;
@@ -399,8 +400,8 @@ export class QuestionKYCUsecase {
     }
   }
 
-  private updateQuestionChoixMultiple(
-    kyc: QuestionChoixMultiple,
+  private updateQuestionChoixMultiple<ID extends KYCID>(
+    kyc: QuestionChoixMultiple<ID>,
     input_reponse_payload: {
       code?: string;
       value?: string;

--- a/test/TestUtil.ts
+++ b/test/TestUtil.ts
@@ -940,8 +940,8 @@ export class TestUtil {
         code: KYCID.KYC_type_logement,
         type: TypeReponseQuestionKYC.choix_unique,
         reponses: [
-          { code: TypeLogement.appartement, label: 'Appartement' },
-          { code: TypeLogement.maison, label: 'Maison' },
+          { code: 'type_appartement', label: 'Appartement' },
+          { code: 'type_maison', label: 'Maison' },
         ],
       }),
       TestUtil.create(DB.kYC, {

--- a/test/integration/api/kyc.controller.ext-spec.ts
+++ b/test/integration/api/kyc.controller.ext-spec.ts
@@ -1,9 +1,7 @@
-import { KYCID } from '../../../src/domain/kyc/KYCID';
-import { Scope } from '../../../src/domain/utilisateur/utilisateur';
 import { KycRepository } from '../../../src/infrastructure/repository/kyc.repository';
 import { UtilisateurRepository } from '../../../src/infrastructure/repository/utilisateur/utilisateur.repository';
-import { DB, TestUtil } from '../../TestUtil';
-import _kyc_hisotry from './kyc_history_test.json';
+import { TestUtil } from '../../TestUtil';
+// import _kyc_hisotry from './kyc_history_test.json';
 
 describe('/utilisateurs - KYC misc test', () => {
   const OLD_ENV = process.env;
@@ -21,30 +19,30 @@ describe('/utilisateurs - KYC misc test', () => {
     process.env.EMAIL_ENABLED = 'false';
   });
 
-  it.skip(`Verification du calcul des conditions 'Quel type de carburant utilise votre voiture ?'`, async () => {
-    // GIVEN
-    process.env.NGC_API_KEY = '12345';
-    TestUtil.token = '12345';
-    process.env.CRON_API_KEY = '12345';
-    TestUtil.token = '12345';
-
-    const reponse_injectKYCs = await TestUtil.POST('/admin/load_kycs_from_cms');
-    expect(reponse_injectKYCs.status).toEqual(201);
-
-    await kycRepository.loadCache();
-
-    await TestUtil.create(DB.utilisateur, { kyc: _kyc_hisotry as any });
-
-    // THEN
-
-    const db_user = await utilisateurRepository.getById('utilisateur-id', [
-      Scope.ALL,
-    ]);
-
-    db_user.kyc_history.isKYCEligible(
-      db_user.kyc_history.getQuestion(
-        KYCID.KYC_transport_voiture_thermique_carburant,
-      ),
-    );
-  });
+  // it.skip(`Verification du calcul des conditions 'Quel type de carburant utilise votre voiture ?'`, async () => {
+  //   // GIVEN
+  //   process.env.NGC_API_KEY = '12345';
+  //   TestUtil.token = '12345';
+  //   process.env.CRON_API_KEY = '12345';
+  //   TestUtil.token = '12345';
+  //
+  //   const reponse_injectKYCs = await TestUtil.POST('/admin/load_kycs_from_cms');
+  //   expect(reponse_injectKYCs.status).toEqual(201);
+  //
+  //   await kycRepository.loadCache();
+  //
+  //   await TestUtil.create(DB.utilisateur, { kyc: _kyc_hisotry as any });
+  //
+  //   // THEN
+  //
+  //   const db_user = await utilisateurRepository.getById('utilisateur-id', [
+  //     Scope.ALL,
+  //   ]);
+  //
+  //   db_user.kyc_history.isKYCEligible(
+  //     db_user.kyc_history.getQuestion(
+  //       KYCID.KYC_transport_voiture_thermique_carburant,
+  //     ),
+  //   );
+  // });
 });

--- a/test/integration/api/questionKYC_v2.controller.int-spec.ts
+++ b/test/integration/api/questionKYC_v2.controller.int-spec.ts
@@ -1765,7 +1765,7 @@ describe('/utilisateurs/id/questionsKYC_v2 (API test)', () => {
     ]);
     user.kyc_history.setCatalogue(KycRepository.getCatalogue());
     expect(
-      user.kyc_history.getQuestionChoix('_2').getSelectedCodes(),
+      user.kyc_history.getQuestionChoix(KYCID._2).getSelectedCodes(),
     ).toStrictEqual([Thematique.climat, Thematique.logement]);
 
     const userDB = await utilisateurRepository.getById('utilisateur-id', [
@@ -1785,7 +1785,7 @@ describe('/utilisateurs/id/questionsKYC_v2 (API test)', () => {
       answered_questions: [
         {
           ...KYC_DATA,
-          code: '1',
+          code: KYCID._1,
           id_cms: 1,
           type: TypeReponseQuestionKYC.choix_unique,
           reponse_complexe: [
@@ -1812,7 +1812,7 @@ describe('/utilisateurs/id/questionsKYC_v2 (API test)', () => {
     await TestUtil.create(DB.utilisateur, { kyc: kyc as any });
     await TestUtil.create(DB.kYC, {
       id_cms: 1,
-      code: '1',
+      code: KYCID._1,
       question: `Quel est votre sujet principal d'intéret ?`,
       reponses: [
         { label: 'Le climat', code: Thematique.climat },
@@ -1825,7 +1825,7 @@ describe('/utilisateurs/id/questionsKYC_v2 (API test)', () => {
 
     // WHEN
     const response = await TestUtil.PUT(
-      '/utilisateurs/utilisateur-id/questionsKYC_v2/1',
+      `/utilisateurs/utilisateur-id/questionsKYC_v2/${KYCID._1}`,
     ).send([
       { code: Thematique.climat, selected: false },
       { code: Thematique.logement, selected: false },
@@ -1839,7 +1839,7 @@ describe('/utilisateurs/id/questionsKYC_v2 (API test)', () => {
     ]);
     user.kyc_history.setCatalogue(KycRepository.getCatalogue());
     expect(
-      user.kyc_history.getQuestionChoix('1').getSelectedCodes(),
+      user.kyc_history.getQuestionChoix(KYCID._1).getSelectedCodes(),
     ).toStrictEqual([Thematique.alimentation]);
   });
 

--- a/test/integration/usecase/mesAidesReno.usecase.int-spec.ts
+++ b/test/integration/usecase/mesAidesReno.usecase.int-spec.ts
@@ -123,7 +123,7 @@ describe('Mes Aides Réno', () => {
         utilisateur.kyc_history
           .getQuestion(KYCID.KYC_type_logement)
           .getSelectedCode(),
-      ).toEqual(TypeLogement.maison);
+      ).toEqual('type_maison');
 
       expect(utilisateur.logement.superficie).toBe(Superficie.superficie_35);
       expect(


### PR DESCRIPTION
Utilise la définition de type `KYCComplexValues` pour avoir un type checking plus fort lorsque l'on manipule les codes de questions : 
<img width="3494" height="344" alt="image" src="https://github.com/user-attachments/assets/4500bc62-78b5-4289-b9e2-720d7a8dd0e3" />
