### PR TITLE
refactor: hardcode la définition enchainements de KYCs pour les actions de type simulateurs

### DIFF
--- a/src/domain/actions/actionMappingEnchainements.ts
+++ b/src/domain/actions/actionMappingEnchainements.ts
@@ -1,5 +1,5 @@
 import { EnchainementType } from '../kyc/enchainementDefinition';
-import { ActionBilanID } from './typeAction';
+import { ActionBilanID, ActionSimulateurID } from './typeAction';
 
 export const ACTION_BILAN_MAPPING_ENCHAINEMENTS: {
   [id in ActionBilanID]: EnchainementType;
@@ -12,4 +12,15 @@ export const ACTION_BILAN_MAPPING_ENCHAINEMENTS: {
     EnchainementType.ENCHAINEMENT_KYC_bilan_logement,
   [ActionBilanID.action_bilan_transports]:
     EnchainementType.ENCHAINEMENT_KYC_bilan_transport,
+};
+
+export const ACTION_SIMULATEUR_MAPPING_ENCHAINEMENTS: {
+  [id in ActionSimulateurID]: EnchainementType | undefined;
+} = {
+  action_simulateur_maif: undefined,
+  action_simulateur_voiture:
+    EnchainementType.ENCHAINEMENT_KYC_action_simulateur_voiture,
+  actions_watt_watchers:
+    EnchainementType.ENCHAINEMENT_KYC_actions_watt_watchers,
+  simu_aides_reno: undefined,
 };

--- a/src/domain/actions/typeAction.ts
+++ b/src/domain/actions/typeAction.ts
@@ -1,13 +1,20 @@
 export enum TypeAction {
+  bilan = 'bilan',
   classique = 'classique',
   quizz = 'quizz',
-  bilan = 'bilan',
   simulateur = 'simulateur',
 }
 
 export enum ActionBilanID {
   action_bilan_alimentation = 'action_bilan_alimentation',
-  action_bilan_transports = 'action_bilan_transports',
-  action_bilan_logement = 'action_bilan_logement',
   action_bilan_conso = 'action_bilan_conso',
+  action_bilan_logement = 'action_bilan_logement',
+  action_bilan_transports = 'action_bilan_transports',
+}
+
+export enum ActionSimulateurID {
+  action_simulateur_maif = 'action_simulateur_maif',
+  action_simulateur_voiture = 'action_simulateur_voiture',
+  actions_watt_watchers = 'actions_watt_watchers',
+  simu_aides_reno = 'simu_aides_reno',
 }

--- a/src/domain/kyc/enchainementDefinition.ts
+++ b/src/domain/kyc/enchainementDefinition.ts
@@ -3,15 +3,17 @@ import { KYCMosaicID } from './mosaicDefinition';
 
 export enum EnchainementType {
   ENCHAINEMENT_KYC_1 = 'ENCHAINEMENT_KYC_1',
-  ENCHAINEMENT_KYC_mini_bilan_carbone = 'ENCHAINEMENT_KYC_mini_bilan_carbone',
-  ENCHAINEMENT_KYC_bilan_transport = 'ENCHAINEMENT_KYC_bilan_transport',
-  ENCHAINEMENT_KYC_bilan_logement = 'ENCHAINEMENT_KYC_bilan_logement',
-  ENCHAINEMENT_KYC_bilan_consommation = 'ENCHAINEMENT_KYC_bilan_consommation',
+  ENCHAINEMENT_KYC_action_simulateur_voiture = 'ENCHAINEMENT_KYC_action_simulateur_voiture',
+  ENCHAINEMENT_KYC_actions_watt_watchers = 'ENCHAINEMENT_KYC_actions_watt_watchers',
   ENCHAINEMENT_KYC_bilan_alimentation = 'ENCHAINEMENT_KYC_bilan_alimentation',
+  ENCHAINEMENT_KYC_bilan_consommation = 'ENCHAINEMENT_KYC_bilan_consommation',
+  ENCHAINEMENT_KYC_bilan_logement = 'ENCHAINEMENT_KYC_bilan_logement',
+  ENCHAINEMENT_KYC_bilan_transport = 'ENCHAINEMENT_KYC_bilan_transport',
+  ENCHAINEMENT_KYC_mini_bilan_carbone = 'ENCHAINEMENT_KYC_mini_bilan_carbone',
   ENCHAINEMENT_KYC_personnalisation_alimentation = 'ENCHAINEMENT_KYC_personnalisation_alimentation',
+  ENCHAINEMENT_KYC_personnalisation_consommation = 'ENCHAINEMENT_KYC_personnalisation_consommation',
   ENCHAINEMENT_KYC_personnalisation_logement = 'ENCHAINEMENT_KYC_personnalisation_logement',
   ENCHAINEMENT_KYC_personnalisation_transport = 'ENCHAINEMENT_KYC_personnalisation_transport',
-  ENCHAINEMENT_KYC_personnalisation_consommation = 'ENCHAINEMENT_KYC_personnalisation_consommation',
 }
 
 export const EnchainementDefinition: Record<
@@ -19,14 +21,67 @@ export const EnchainementDefinition: Record<
   (KYCID | KYCMosaicID)[]
 > = {
   ENCHAINEMENT_KYC_1: [KYCID.KYC001, KYCMosaicID.TEST_MOSAIC_ID],
-  ENCHAINEMENT_KYC_mini_bilan_carbone: [
+  ENCHAINEMENT_KYC_action_simulateur_voiture: [
+    KYCID.KYC_transport_type_utilisateur,
+    KYCID.KYC_transport_voiture_occasion,
     KYCID.KYC_transport_voiture_km,
-    KYCID.KYC_transport_avion_3_annees,
-    KYCMosaicID.MOSAIC_CHAUFFAGE,
+    KYCID.KYC_transport_voiture_duree_detention,
+    KYCID.KYC_transport_voiture_annee_fabrication,
+    KYCID.KYC_transport_voiture_prix_achat,
+    KYCID.KYC_transport_voiture_gabarit,
+    KYCID.KYC_transport_voiture_motorisation,
+    KYCID.KYC_transport_voiture_thermique_carburant,
+    KYCID.KYC_transport_voiture_thermique_consomation_carburant,
+    KYCID.KYC_transport_voiture_thermique_prix_carburant,
+    KYCID.KYC_transport_voiture_electrique_consommation,
+    KYCID.KYC_transport_voiture_electrique_prix_kwh,
+    KYCID.KYC_transport_voiture_couts_entretien,
+    KYCID.KYC_transport_voiture_couts_assurance,
+    KYCID.KYC_transport_voiture_couts_stationnement,
+    KYCID.KYC_transport_voiture_couts_peage,
+  ],
+  ENCHAINEMENT_KYC_actions_watt_watchers: [
+    KYCID.KYC_type_logement,
+    KYCID.KYC_proprietaire,
     KYCID.KYC_superficie,
+    KYCID.KYC_logement_age,
     KYCID.KYC_menage,
-    KYCID.KYC_alimentation_regime,
-    KYCID.KYC_consommation_type_consommateur,
+    KYCID.KYC_chauffage,
+    KYCID.KYC_type_chauffage_eau,
+    KYCID.KYC_chauffage_reseau,
+    KYCID.KYC_logement_reno_second_oeuvre,
+    KYCID.KYC_electro_refrigerateur,
+  ],
+  ENCHAINEMENT_KYC_bilan_alimentation: [
+    KYCID.KYC_alimentation_regime, // manque quand import NGC Full
+    KYCID.KYC_petitdej,
+    KYCID.KYC_local_frequence,
+    KYCID.KYC_saison_frequence,
+    KYCID.KYC_alimentation_litres_alcool,
+    KYCID.KYC_gaspillage_alimentaire_frequence,
+    KYCMosaicID.MOSAIC_REDUCTION_DECHETS,
+  ],
+  ENCHAINEMENT_KYC_bilan_consommation: [
+    KYCID.KYC_consommation_type_consommateur, // manque quand import NGC Full
+    KYCMosaicID.MOSAIC_LOGEMENT_VACANCES,
+    KYCID.KYC_consommation_relation_objets,
+    KYCMosaicID.MOSAIC_ELECTROMENAGER,
+    KYCMosaicID.MOSAIC_ANIMAUX,
+    KYCMosaicID.MOSAIC_APPAREIL_NUM,
+    KYCMosaicID.MOSAIC_MEUBLES,
+    KYCID.KYC_raison_achat_vetements,
+  ],
+  ENCHAINEMENT_KYC_bilan_logement: [
+    KYCID.KYC_type_logement,
+    KYCID.KYC_menage,
+    KYCID.KYC_superficie,
+    KYCID.KYC_logement_age,
+    KYCMosaicID.MOSAIC_CHAUFFAGE,
+    KYCID.KYC_temperature,
+    // TODO: KYCID.KYC_conso_elec,
+    KYCMosaicID.MOSAIC_RENO,
+    KYCID.KYC_photovoltaiques,
+    KYCMosaicID.MOSAIC_EXTERIEUR,
   ],
   ENCHAINEMENT_KYC_bilan_transport: [
     KYCID.KYC_transport_avion_3_annees,
@@ -47,36 +102,14 @@ export const EnchainementDefinition: Record<
     KYCID.KYC_2roue_motorisation_type,
     KYCID.KYC_2roue_km,
   ],
-  ENCHAINEMENT_KYC_bilan_logement: [
-    KYCID.KYC_type_logement,
-    KYCID.KYC_menage,
-    KYCID.KYC_superficie,
-    KYCID.KYC_logement_age,
+  ENCHAINEMENT_KYC_mini_bilan_carbone: [
+    KYCID.KYC_transport_voiture_km,
+    KYCID.KYC_transport_avion_3_annees,
     KYCMosaicID.MOSAIC_CHAUFFAGE,
-    KYCID.KYC_temperature,
-    // TODO: KYCID.KYC_conso_elec,
-    KYCMosaicID.MOSAIC_RENO,
-    KYCID.KYC_photovoltaiques,
-    KYCMosaicID.MOSAIC_EXTERIEUR,
-  ],
-  ENCHAINEMENT_KYC_bilan_consommation: [
-    KYCID.KYC_consommation_type_consommateur, // manque quand import NGC Full
-    KYCMosaicID.MOSAIC_LOGEMENT_VACANCES,
-    KYCID.KYC_consommation_relation_objets,
-    KYCMosaicID.MOSAIC_ELECTROMENAGER,
-    KYCMosaicID.MOSAIC_ANIMAUX,
-    KYCMosaicID.MOSAIC_APPAREIL_NUM,
-    KYCMosaicID.MOSAIC_MEUBLES,
-    KYCID.KYC_raison_achat_vetements,
-  ],
-  ENCHAINEMENT_KYC_bilan_alimentation: [
-    KYCID.KYC_alimentation_regime, // manque quand import NGC Full
-    KYCID.KYC_petitdej,
-    KYCID.KYC_local_frequence,
-    KYCID.KYC_saison_frequence,
-    KYCID.KYC_alimentation_litres_alcool,
-    KYCID.KYC_gaspillage_alimentaire_frequence,
-    KYCMosaicID.MOSAIC_REDUCTION_DECHETS,
+    KYCID.KYC_superficie,
+    KYCID.KYC_menage,
+    KYCID.KYC_alimentation_regime,
+    KYCID.KYC_consommation_type_consommateur,
   ],
   ENCHAINEMENT_KYC_personnalisation_alimentation: [
     KYCID.KYC_alimentation_regime,
@@ -84,10 +117,9 @@ export const EnchainementDefinition: Record<
     KYCMosaicID.MOSAIC_REDUCTION_DECHETS,
     KYCID.KYC_local_frequence,
   ],
-  ENCHAINEMENT_KYC_personnalisation_transport: [
-    KYCID.KYC_transport_avion_3_annees,
-    KYCID.KYC003,
-    KYCID.KYC_possede_voiture_oui_non,
+  ENCHAINEMENT_KYC_personnalisation_consommation: [
+    KYCID.KYC_consommation_relation_objets,
+    KYCID.KYC_consommation_type_consommateur,
   ],
   ENCHAINEMENT_KYC_personnalisation_logement: [
     KYCID.KYC_type_logement,
@@ -96,8 +128,9 @@ export const EnchainementDefinition: Record<
     KYCMosaicID.MOSAIC_CHAUFFAGE,
     KYCMosaicID.MOSAIC_RENO,
   ],
-  ENCHAINEMENT_KYC_personnalisation_consommation: [
-    KYCID.KYC_consommation_relation_objets,
-    KYCID.KYC_consommation_type_consommateur,
+  ENCHAINEMENT_KYC_personnalisation_transport: [
+    KYCID.KYC_transport_avion_3_annees,
+    KYCID.KYC003,
+    KYCID.KYC_possede_voiture_oui_non,
   ],
 };

--- a/src/infrastructure/repository/action.repository.ts
+++ b/src/infrastructure/repository/action.repository.ts
@@ -88,6 +88,7 @@ export class ActionRepository {
     const action_def = this.getActionDefinitionByTypeCode(action);
     return action_def && action_def.type === TypeAction.simulateur;
   }
+
   public isBilan(action: TypeCodeAction): boolean {
     const action_def = this.getActionDefinitionByTypeCode(action);
     return action_def && action_def.type === TypeAction.bilan;

--- a/src/usecase/actions.usecase.ts
+++ b/src/usecase/actions.usecase.ts
@@ -461,16 +461,7 @@ export class ActionUsecase {
           ]
         : undefined;
 
-    if (enchainement_id) {
-      return EnchainementDefinition[enchainement_id];
-    } else {
-      const action_def = this.actionRepository.getActionDefinitionByTypeCode({
-        type: action_type,
-        code: action_code,
-      });
-
-      return action_def ? action_def.kyc_codes : [];
-    }
+    return EnchainementDefinition[enchainement_id] ?? [];
   }
 
   public async calculeScoreQuizzAction(

--- a/src/usecase/catalogue_actions.usecase.ts
+++ b/src/usecase/catalogue_actions.usecase.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { Action } from '../domain/actions/action';
-import { ACTION_BILAN_MAPPING_ENCHAINEMENTS } from '../domain/actions/actionBilanMappingEnchainements';
 import {
   CatalogueAction,
   Consultation,
@@ -8,10 +7,8 @@ import {
   Realisation,
   Recommandation,
 } from '../domain/actions/catalogueAction';
-import { ActionBilanID, TypeAction } from '../domain/actions/typeAction';
 import { Echelle } from '../domain/aides/echelle';
 import { Selection } from '../domain/contenu/selection';
-import { EnchainementDefinition } from '../domain/kyc/enchainementDefinition';
 import { Thematique } from '../domain/thematique/thematique';
 import { Scope, Utilisateur } from '../domain/utilisateur/utilisateur';
 import { ApplicationError } from '../infrastructure/applicationError';
@@ -257,23 +254,6 @@ export class CatalogueActionUsecase {
     );
 
     return actions_resultat;
-  }
-
-  public external_get_kyc_codes_from_action_bilan(
-    code_action: string,
-  ): string[] {
-    const enchainement_id =
-      ACTION_BILAN_MAPPING_ENCHAINEMENTS[ActionBilanID[code_action]];
-
-    if (enchainement_id) {
-      return EnchainementDefinition[enchainement_id];
-    } else {
-      const action_def = this.actionRepository.getActionDefinitionByTypeCode({
-        type: TypeAction.bilan,
-        code: code_action,
-      });
-      return action_def ? action_def.kyc_codes : [];
-    }
   }
 
   async external_count_actions(thematique?: Thematique): Promise<number> {

--- a/test/integration/api/actions.controller.int-spec.ts
+++ b/test/integration/api/actions.controller.int-spec.ts
@@ -1,6 +1,11 @@
-import { TypeAction } from '../../../src/domain/actions/typeAction';
+import {
+  ActionBilanID,
+  ActionSimulateurID,
+  TypeAction,
+} from '../../../src/domain/actions/typeAction';
 import { Echelle } from '../../../src/domain/aides/echelle';
 import { Categorie } from '../../../src/domain/contenu/categorie';
+import { KYCID } from '../../../src/domain/kyc/KYCID';
 import { TypeReponseQuestionKYC } from '../../../src/domain/kyc/questionKYC';
 import {
   Chauffage,
@@ -404,19 +409,24 @@ describe('Actions (API test)', () => {
   it(`GET /utilisateurs/id/actions/id - action de type simulateur doit contenir une liste de KYCs (quelles soient répondues ou non)`, async () => {
     // GIVEN
     const KYC2 = {
-      id_cms: 502,
-      code: 'KYC2',
+      id_cms: 1,
+      code: KYCID.KYC_transport_type_utilisateur,
+      question: 'Quel est votre moyen de transport principal ?',
       type: TypeReponseQuestionKYC.entier,
-      question: '',
       categorie: Categorie.test,
       points: 0,
       is_ngc: false,
       tags: [],
-      thematique: Thematique.alimentation,
+      thematique: Thematique.transport,
       conditions: [],
     };
-    await TestUtil.create(DB.kYC, { id_cms: 501, code: 'KYC1' });
-    await TestUtil.create(DB.kYC, KYC2 as any);
+    await TestUtil.create(DB.kYC, KYC2);
+    await TestUtil.create(DB.kYC, {
+      id_cms: 2,
+      code: KYCID.KYC_transport_voiture_occasion,
+      question: "Votre voiture est-elle d'occasion ?",
+    });
+
     const kyc: KYCHistory_v2 = {
       version: 2,
       answered_mosaics: [],
@@ -435,41 +445,40 @@ describe('Actions (API test)', () => {
       logement: logement as any,
       kyc: kyc as any,
     });
+    const type_code_id = `${TypeAction.simulateur}_${ActionSimulateurID.action_simulateur_voiture}`;
     await TestUtil.create(DB.action, {
-      code: '123',
+      code: ActionSimulateurID.action_simulateur_voiture,
       type: TypeAction.simulateur,
-      kyc_codes: ['KYC1', 'KYC2'],
-      type_code_id: 'simulateur_123',
+      type_code_id,
     });
     await kycRepository.loadCache();
     await actionRepository.loadCache();
 
     // WHEN
     const response = await TestUtil.GET(
-      '/utilisateurs/utilisateur-id/actions/simulateur/123',
+      `/utilisateurs/utilisateur-id/actions/simulateur/${ActionSimulateurID.action_simulateur_voiture}`,
     );
 
     // THEN
     expect(response.status).toBe(200);
     expect(response.body.kycs).toHaveLength(2);
-    expect(response.body.enchainement_id).toEqual('simulateur_123');
+    expect(response.body.enchainement_id).toEqual(type_code_id);
   });
 
   it(`GET /utilisateurs/id/actions/id - action de type bilan doit contenir une liste de KYCs (quelles soient répondues ou non)`, async () => {
     // GIVEN
     const KYC2 = {
       id_cms: 502,
-      code: 'KYC2',
+      code: KYCID.KYC_type_logement,
       type: TypeReponseQuestionKYC.entier,
-      question: '',
+      question: 'Quel est le type de votre logement ?',
       categorie: Categorie.test,
       points: 0,
       is_ngc: false,
       tags: [],
-      thematique: Thematique.alimentation,
+      thematique: Thematique.logement,
       conditions: [],
     };
-    await TestUtil.create(DB.kYC, { id_cms: 501, code: 'KYC1' });
     await TestUtil.create(DB.kYC, KYC2 as any);
     const kyc: KYCHistory_v2 = {
       version: 2,
@@ -489,24 +498,24 @@ describe('Actions (API test)', () => {
       logement: logement as any,
       kyc: kyc as any,
     });
+    const type_code_id = `${TypeAction.bilan}_${ActionBilanID.action_bilan_logement}`;
     await TestUtil.create(DB.action, {
-      code: '123',
+      code: ActionBilanID.action_bilan_logement,
       type: TypeAction.bilan,
-      kyc_codes: ['KYC1', 'KYC2'],
-      type_code_id: 'bilan_123',
+      type_code_id,
     });
     await kycRepository.loadCache();
     await actionRepository.loadCache();
 
     // WHEN
     const response = await TestUtil.GET(
-      '/utilisateurs/utilisateur-id/actions/bilan/123',
+      `/utilisateurs/utilisateur-id/actions/bilan/${ActionBilanID.action_bilan_logement}`,
     );
 
     // THEN
     expect(response.status).toBe(200);
-    expect(response.body.kycs).toHaveLength(2);
-    expect(response.body.enchainement_id).toEqual('bilan_123');
+    expect(response.body.kycs).toHaveLength(4);
+    expect(response.body.enchainement_id).toEqual(type_code_id);
   });
 
   it(`GET /utilisateurs/id/actions/id - accroche les quizz liés à l'action`, async () => {

--- a/test/integration/api/questionKYC_v2Enchainement.controller.int-spec.ts
+++ b/test/integration/api/questionKYC_v2Enchainement.controller.int-spec.ts
@@ -10,6 +10,7 @@ import {
 
 import {
   ActionBilanID,
+  ActionSimulateurID,
   TypeAction,
 } from '../../../src/domain/actions/typeAction';
 import { EnchainementDefinition } from '../../../src/domain/kyc/enchainementDefinition';
@@ -310,34 +311,32 @@ describe('/utilisateurs/id/enchainementQuestionsKYC_v2 (API test)', () => {
 
   it(`GET /utilisateurs/id/enchainementQuestionsKYC_v2/id/first - ID de simultateur`, async () => {
     // GIVEN
-
     await TestUtil.create(DB.kYC, {
       ...dbKYC,
       id_cms: 1,
-      question: 'quest 1',
-      code: KYCID.KYC001,
+      code: KYCID.KYC_transport_type_utilisateur,
+      question: 'Quel est votre moyen de transport principal ?',
     });
     await TestUtil.create(DB.kYC, {
       ...dbKYC,
       id_cms: 2,
-      question: 'quest 2',
-      code: KYCID.KYC002,
+      code: KYCID.KYC_transport_voiture_occasion,
+      question: "Votre voiture est-elle d'occasion ?",
     });
+
+    const type_code_id = `${TypeAction.simulateur}_${ActionSimulateurID.action_simulateur_voiture}`;
     await TestUtil.create(DB.action, {
-      code: '123',
+      code: ActionSimulateurID.action_simulateur_voiture,
       type: TypeAction.simulateur,
-      type_code_id: 'simulateur_123',
-      label_compteur: 'ttt',
-      kyc_codes: ['KYC001', 'KYC002'],
+      type_code_id,
     });
 
     await TestUtil.create(DB.utilisateur);
     await kycRepository.loadCache();
     await actionRepository.loadCache();
 
-    // WHEN
     const response = await TestUtil.GET(
-      '/utilisateurs/utilisateur-id/enchainementQuestionsKYC_v2/simulateur_123/first',
+      `/utilisateurs/utilisateur-id/enchainementQuestionsKYC_v2/${type_code_id}/first`,
     );
 
     // THEN
@@ -351,83 +350,12 @@ describe('/utilisateurs/id/enchainementQuestionsKYC_v2 (API test)', () => {
       is_out_of_range: false,
       question_courante: {
         categorie: 'recommandation',
-        code: 'KYC001',
+        code: KYCID.KYC_transport_type_utilisateur,
         is_NGC: true,
         is_answered: false,
         is_skipped: false,
         points: 20,
-        question: 'quest 1',
-        reponse_multiple: [
-          {
-            code: 'oui',
-            label: 'Oui',
-            selected: false,
-          },
-          {
-            code: 'non',
-            label: 'Non',
-            selected: false,
-          },
-          {
-            code: 'sais_pas',
-            label: 'Je sais pas',
-            selected: false,
-          },
-        ],
-        thematique: 'alimentation',
-        type: 'choix_unique',
-      },
-    });
-  });
-
-  it(`GET /utilisateurs/id/enchainementQuestionsKYC_v2/id/first - ID de bilan`, async () => {
-    // GIVEN
-    await TestUtil.create(DB.kYC, {
-      ...dbKYC,
-      id_cms: 1,
-      question: 'quest 1',
-      code: KYCID.KYC001,
-    });
-    await TestUtil.create(DB.kYC, {
-      ...dbKYC,
-      id_cms: 2,
-      question: 'quest 2',
-      code: KYCID.KYC002,
-    });
-    await TestUtil.create(DB.action, {
-      code: '123',
-      type: TypeAction.bilan,
-      type_code_id: 'bilan_123',
-      label_compteur: 'ttt',
-      kyc_codes: ['KYC001', 'KYC002'],
-    });
-
-    await TestUtil.create(DB.utilisateur);
-    await kycRepository.loadCache();
-    await actionRepository.loadCache();
-
-    // WHEN
-    const response = await TestUtil.GET(
-      '/utilisateurs/utilisateur-id/enchainementQuestionsKYC_v2/bilan_123/first',
-    );
-
-    // THEN
-    expect(response.status).toBe(200);
-    expect(response.body).toEqual({
-      nombre_total_questions: 2,
-      nombre_total_questions_effectives: 2,
-      position_courante: 1,
-      is_first: true,
-      is_last: false,
-      is_out_of_range: false,
-      question_courante: {
-        categorie: 'recommandation',
-        code: 'KYC001',
-        is_NGC: true,
-        is_answered: false,
-        is_skipped: false,
-        points: 20,
-        question: 'quest 1',
+        question: 'Quel est votre moyen de transport principal ?',
         reponse_multiple: [
           {
             code: 'oui',


### PR DESCRIPTION
Initialement, les enchainements de KYCs pour les actions de type simulateur étaient définis directement depuis le CMS. N'ayant qu'un seul CMS pour la prod et le dev, cela ne permet pas de pouvoir définir des enchainements différents. De plus, cela complique la gestion des enchainements et diffère du fonctionnement des actions de type bilan.

Avec cette PR, tous les enchainements sont donc à présent définis au même endroit permettant de pallier ces problèmes et en facilite la maintenance.