### PR TITLE
Corrige la valeur par défaut de `compteur_label`  pour les actions

### DIFF
--- a/src/infrastructure/prisma/migrations/20250811101550_fix_compteur_label/migration.sql
+++ b/src/infrastructure/prisma/migrations/20250811101550_fix_compteur_label/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Action" ALTER COLUMN "label_compteur" SET DEFAULT '**{NBR_ACTIONS}** actions réalisées par la communauté';

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -173,7 +173,7 @@ model Action {
   titre_recherche        String?
   sous_titre             String?
   consigne               String   @default("Réalisez cette action dans les prochaines semaines et partagez vos retours")
-  label_compteur         String   @default("**453 actions** réalisées par la communauté")
+  label_compteur         String   @default("**{NBR_ACTIONS}** actions réalisées par la communauté")
   quizz_felicitations    String?
   pourquoi               String?
   comment                String?

--- a/src/usecase/CMSDataHelper.usecase.ts
+++ b/src/usecase/CMSDataHelper.usecase.ts
@@ -87,6 +87,35 @@ export type ActionData = {
   updatedBy: number;
 };
 
+export class ActionCMSDataHelper {
+  static getTitreRcherche(titre?: string): string {
+    return titre ? titre.replaceAll('*', '') : '';
+  }
+
+  static getConsigne(consigne?: string): string {
+    return (
+      consigne ??
+      'Réalisez cette action dans les prochaines semaines et partagez vos retours'
+    );
+  }
+
+  static getLabelCompteur(label_compteur?: string): string {
+    return (
+      label_compteur ?? '**{NBR_ACTIONS}** actions réalisées par la communauté'
+    );
+  }
+
+  static getPartenaireId(partenaire?: PartenaireData): number {
+    return partenaire ? partenaire.id : null;
+  }
+
+  static getSources(sources?: SourceData[]): { label: string; url: string }[] {
+    return sources
+      ? sources.map((s) => ({ label: s.libelle, url: s.lien }))
+      : [];
+  }
+}
+
 export type AideData = {
   id: number; //3,
   titre?: string; //"Acheter un vélo",

--- a/src/usecase/cms.import.usecase.ts
+++ b/src/usecase/cms.import.usecase.ts
@@ -40,6 +40,7 @@ import { PartenaireRepository } from '../infrastructure/repository/partenaire.re
 import { SelectionRepository } from '../infrastructure/repository/selection.repository';
 import { TagRepository } from '../infrastructure/repository/tag.repository';
 import { ThematiqueRepository } from '../infrastructure/repository/thematique.repository';
+import { ActionCMSDataHelper } from './CMSDataHelper.usecase';
 import { PartenaireUsecase } from './partenaire.usecase';
 
 const FULL_POPULATE_URL =
@@ -750,16 +751,14 @@ export class CMSImportUsecase {
           : null,
       code: entry.attributes.code,
       titre: entry.attributes.titre,
-      titre_recherche: entry.attributes.titre
-        ? entry.attributes.titre.replaceAll('*', '')
-        : '',
+      titre_recherche: ActionCMSDataHelper.getTitreRcherche(
+        entry.attributes.titre,
+      ),
       sous_titre: entry.attributes.sous_titre,
-      consigne:
-        entry.attributes.consigne ||
-        'Réalisez cette action dans les prochaines semaines et partagez vos retours',
-      label_compteur:
-        entry.attributes.label_compteur ||
-        '**{NBR_ACTIONS}** actions réalisées par la communauté',
+      consigne: ActionCMSDataHelper.getConsigne(entry.attributes.consigne),
+      label_compteur: ActionCMSDataHelper.getLabelCompteur(
+        entry.attributes.label_compteur,
+      ),
       pourquoi: entry.attributes.pourquoi,
       comment: entry.attributes.comment,
       quizz_felicitations: entry.attributes.felicitations,
@@ -800,12 +799,7 @@ export class CMSImportUsecase {
       thematique: entry.attributes.thematique.data
         ? Thematique[entry.attributes.thematique.data.attributes.code]
         : null,
-      sources: entry.attributes.sources
-        ? entry.attributes.sources.map((s) => ({
-            label: s.libelle,
-            url: s.lien,
-          }))
-        : [],
+      sources: ActionCMSDataHelper.getSources(entry.attributes.sources),
       tags_a_exclure:
         entry.attributes.tag_v2_excluants &&
         entry.attributes.tag_v2_excluants.data.length > 0

--- a/src/usecase/cms.webhook.usecase.ts
+++ b/src/usecase/cms.webhook.usecase.ts
@@ -40,6 +40,7 @@ import { QuizzRepository } from '../infrastructure/repository/quizz.repository';
 import { SelectionRepository } from '../infrastructure/repository/selection.repository';
 import { TagRepository } from '../infrastructure/repository/tag.repository';
 import { ThematiqueRepository } from '../infrastructure/repository/thematique.repository';
+import { ActionCMSDataHelper } from './CMSDataHelper.usecase';
 import { PartenaireUsecase } from './partenaire.usecase';
 
 @Injectable()
@@ -536,15 +537,24 @@ export class CMSWebhookUsecase {
     };
   }
 
+  /**
+   * FIXME: this function should be factorized with the equivalent one in the
+   * cms.import.usecase.ts to avoid code duplication, and therefore,
+   * desynchronization.
+   *
+   * @note for the moment, only some fields have been factorized with {@link ActionCMSDataHelper}
+   **/
   private buildActionFromCMSData(entry: CMSWebhookEntryAPI): ActionDefinition {
     return new ActionDefinition({
       cms_id: entry.id.toString(),
       partenaire_id: entry.partenaire ? '' + entry.partenaire.id : null,
       titre: entry.titre,
-      titre_recherche: entry.titre ? entry.titre.replaceAll('*', '') : '',
+      titre_recherche: ActionCMSDataHelper.getTitreRcherche(entry.titre),
       sous_titre: entry.sous_titre,
-      consigne: entry.consigne,
-      label_compteur: entry.label_compteur,
+      consigne: ActionCMSDataHelper.getConsigne(entry.consigne),
+      label_compteur: ActionCMSDataHelper.getLabelCompteur(
+        entry.label_compteur,
+      ),
       pourquoi: entry.pourquoi,
       comment: entry.comment,
       quizz_felicitations: entry.felicitations,
@@ -573,17 +583,13 @@ export class CMSWebhookUsecase {
         : null,
       thematique: entry.thematique ? Thematique[entry.thematique.code] : null,
       code: entry.code,
-      sources: entry.sources
-        ? entry.sources.map((s) => ({ label: s.libelle, url: s.lien }))
-        : [],
+      sources: ActionCMSDataHelper.getSources(entry.sources),
       tags_a_exclure: entry.tag_v2_excluants
         ? entry.tag_v2_excluants.map((elem) => elem.code)
         : [],
-
       selections: entry.selections
         ? entry.selections.map((elem) => elem.code)
         : [],
-
       tags_a_inclure: entry.tag_v2_incluants
         ? entry.tag_v2_incluants.map((elem) => elem.code)
         : [],

--- a/test/integration/api/incoming/cms.controller.int-spec.ts
+++ b/test/integration/api/incoming/cms.controller.int-spec.ts
@@ -1150,6 +1150,57 @@ describe('/api/incoming/cms (API test)', () => {
     expect(action.pdcn_categorie).toEqual(CategorieRecherche.circuit_court);
   });
 
+  it('POST /api/incoming/cms - create a new action without label_compteur', async () => {
+    // GIVEN
+
+    // WHEN
+    const response = await TestUtil.POST('/api/incoming/cms').send({
+      ...CMS_DATA_ACTION,
+      entry: {
+        ...CMS_DATA_ACTION.entry,
+        label_compteur: undefined,
+      },
+    });
+
+    // THEN
+    const actions = await TestUtil.prisma.action.findMany({});
+
+    expect(response.status).toBe(201);
+    expect(actions).toHaveLength(1);
+    const action = actions[0];
+    expect(action.label_compteur).toEqual(
+      '**{NBR_ACTIONS}** actions réalisées par la communauté',
+    );
+
+    expect(action.titre).toEqual('titre');
+    expect(action.external_id).toEqual('ext_123');
+    expect(action.partenaire_id).toEqual('1');
+    expect(action.emoji).toEqual('🔥');
+    expect(action.sous_titre).toEqual('sous-titre');
+    expect(action.consigne).toEqual('Faites rapidement');
+    expect(action.besoins).toEqual(['composter', 'mieux_manger']);
+    expect(action.tags_a_inclure_v2).toEqual(['CC', 'DD']);
+    expect(action.tags_a_exclure_v2).toEqual(['AA', 'BB']);
+    expect(action.selections).toEqual(['S1', 'S2']);
+    expect(action.comment).toEqual('comment');
+    expect(action.quizz_felicitations).toEqual('Bravo !!');
+    expect(action.pourquoi).toEqual('pourquoi');
+    expect(action.quizz_ids).toEqual(['1', '2']);
+    expect(action.articles_ids).toEqual(['9', '10']);
+    expect(action.kyc_codes).toEqual(['KYC01', 'KYC02']);
+    expect(action.faq_ids).toEqual(['5', '6']);
+    expect(action.lvo_action).toEqual('donner');
+    expect(action.lvo_objet).toEqual('phone');
+    expect(action.recette_categorie).toEqual('vegan');
+    expect(action.type).toEqual('quizz');
+    expect(action.code).toEqual('code');
+    expect(action.cms_id).toEqual('123');
+    expect(action.sources).toEqual([{ label: 'haha', url: 'hoho' }]);
+    expect(action.thematique).toEqual('alimentation');
+    expect(action.VISIBLE_PROD).toEqual(true);
+    expect(action.pdcn_categorie).toEqual(CategorieRecherche.circuit_court);
+  });
+
   it('POST /api/incoming/cms - create a new action bilan', async () => {
     // GIVEN
 


### PR DESCRIPTION
La valeur par défaut du label pour le compteur d'action n'était pas géré correctement avec le webhook CMS. En effet, n'ayant pas de vérifications comme pour l'import :

https://github.com/betagouv/agir-back/blob/2c798fa2cda96e8ed654b42a9f1be9604b6047f6/src/usecase/cms.import.usecase.ts#L760-L762

La valeur par défaut de la base de donnée était utilisée :

https://github.com/betagouv/agir-back/blob/2c798fa2cda96e8ed654b42a9f1be9604b6047f6/src/infrastructure/prisma/schema.prisma#L176

Cette PR corrige cette incohérence. Cependant, il serait pertinent selon moi de factoriser la logique de création en BD des données entre l'import et le webhook pour éviter de futures désynchronisations.