### PR TITLE
fix: tolérer les accents dans le filtre titre du catalogue actions

### DIFF
--- a/src/infrastructure/repository/action.repository.ts
+++ b/src/infrastructure/repository/action.repository.ts
@@ -35,6 +35,10 @@ export type ActionFilter = {
   realisation?: Realisation;
 };
 
+export function normalizeWithoutAccent(text: string): string {
+  return text.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
+
 @Injectable()
 export class ActionRepository {
   constructor(private prisma: PrismaService) {
@@ -237,7 +241,7 @@ export class ActionRepository {
     if (filtre.titre_fragment) {
       main_filter.push({
         titre_recherche: {
-          contains: filtre.titre_fragment,
+          contains: normalizeWithoutAccent(filtre.titre_fragment),
           mode: 'insensitive',
         },
       });

--- a/src/usecase/CMSDataHelper.usecase.ts
+++ b/src/usecase/CMSDataHelper.usecase.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { readFileSync, writeFileSync } from 'fs';
+import { normalizeWithoutAccent } from '../infrastructure/repository/action.repository';
 
 export type SourceData = {
   id: number;
@@ -89,7 +90,7 @@ export type ActionData = {
 
 export class ActionCMSDataHelper {
   static getTitreRcherche(titre?: string): string {
-    return titre ? titre.replaceAll('*', '') : '';
+    return titre ? normalizeWithoutAccent(titre.replaceAll('*', '')) : '';
   }
 
   static getConsigne(consigne?: string): string {

--- a/test/integration/api/actions.catalogue.offline.controller.int-spec.ts
+++ b/test/integration/api/actions.catalogue.offline.controller.int-spec.ts
@@ -149,6 +149,38 @@ describe('Actions Catalogue Offline (API test)', () => {
 
     expect(action.code).toEqual('2');
   });
+  it(`GET /actions - liste le catalogue recherche texte titre avec accent`, async () => {
+    // GIVEN
+    await TestUtil.create(DB.action, {
+      code: '1',
+      cms_id: '1',
+      type: TypeAction.classique,
+      type_code_id: 'classique_1',
+      thematique: Thematique.alimentation,
+      titre_recherche: 'Une belle energie',
+    });
+    await TestUtil.create(DB.action, {
+      code: '2',
+      cms_id: '2',
+      type: TypeAction.classique,
+      type_code_id: 'classique_2',
+      thematique: Thematique.logement,
+      titre_recherche: 'Une action toute nulle',
+    });
+
+    await actionRepository.onApplicationBootstrap();
+
+    // WHEN
+    const response = await TestUtil.GET('/actions?titre=éner');
+
+    // THEN
+    expect(response.status).toBe(200);
+    expect(response.body.actions.length).toBe(1);
+
+    const action: ActionLightAPI = response.body.actions[0];
+
+    expect(action.code).toEqual('1');
+  });
   it(`GET /actions - liste le catalogue recherche texte titre malgré markdown`, async () => {
     // GIVEN
     await TestUtil.create(DB.action, {


### PR DESCRIPTION
Il faudra reload les actions pour que le titre_recherche se re-popule correctement